### PR TITLE
Implement Streamable HTTP support

### DIFF
--- a/config/mcp-server.php
+++ b/config/mcp-server.php
@@ -57,7 +57,8 @@ return [
     | Server-Sent Events Provider
     |--------------------------------------------------------------------------
     |
-    | The type of server provider to use. Currently only 'sse' is supported.
+    | The type of server provider to use. Supported values are 'sse' and
+    | 'streamable_http'.
     |
     */
     'server_provider' => 'sse',

--- a/src/Http/Controllers/StreamableHttpController.php
+++ b/src/Http/Controllers/StreamableHttpController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace OPGG\LaravelMcpServer\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Response;
+use OPGG\LaravelMcpServer\Server\MCPServer;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Controller handling the Streamable HTTP transport endpoint.
+ */
+final class StreamableHttpController extends Controller
+{
+    public function handle(Request $request)
+    {
+        $server = app(MCPServer::class);
+
+        if ($request->isMethod('get')) {
+            return new StreamedResponse(
+                fn () => $server->connect(),
+                headers: [
+                    'Content-Type' => 'text/event-stream',
+                    'Cache-Control' => 'no-cache',
+                    'X-Accel-Buffering' => 'no',
+                ]
+            );
+        }
+
+        if ($request->isMethod('post')) {
+            $sessionId = $request->header('Mcp-Session-Id');
+            $messageJson = json_decode($request->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+            $server->requestMessage(clientId: (string) $sessionId, message: $messageJson);
+
+            return Response::json(['accepted' => true], 202);
+        }
+
+        return Response::json(['error' => 'Method Not Allowed'], 405);
+    }
+}

--- a/src/Providers/StreamableHttpServiceProvider.php
+++ b/src/Providers/StreamableHttpServiceProvider.php
@@ -33,7 +33,7 @@ final class StreamableHttpServiceProvider extends ServiceProvider
             });
 
             $this->app->singleton(MCPServer::class, function ($app) {
-                $transport = new SseTransport();
+                $transport = new SseTransport;
 
                 $adapterType = Config::get('mcp-server.sse_adapter', 'redis');
                 $adapterFactory = new SseAdapterFactory(adapterType: $adapterType);
@@ -45,7 +45,7 @@ final class StreamableHttpServiceProvider extends ServiceProvider
 
                 $serverInfo = Config::get('mcp-server.server');
 
-                $capabilities = new ServerCapabilities();
+                $capabilities = new ServerCapabilities;
 
                 $toolRepository = app(ToolRepository::class);
                 $capabilities->withTools(['schemas' => $toolRepository->getToolSchemas()]);

--- a/src/Providers/StreamableHttpServiceProvider.php
+++ b/src/Providers/StreamableHttpServiceProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace OPGG\LaravelMcpServer\Providers;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\ServiceProvider;
+use OPGG\LaravelMcpServer\Protocol\MCPProtocol;
+use OPGG\LaravelMcpServer\Server\MCPServer;
+use OPGG\LaravelMcpServer\Server\ServerCapabilities;
+use OPGG\LaravelMcpServer\Services\SseAdapterFactory;
+use OPGG\LaravelMcpServer\Services\ToolService\ToolRepository;
+use OPGG\LaravelMcpServer\Transports\SseTransport;
+
+/**
+ * Streamable HTTP Service Provider.
+ *
+ * Registers the MCPServer when `server_provider` config is set to
+ * `streamable_http`. Internally it uses the existing SSE transport to
+ * deliver streamed messages.
+ */
+final class StreamableHttpServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        if (Config::get('mcp-server.server_provider') === 'streamable_http') {
+            $this->app->singleton(ToolRepository::class, function ($app) {
+                $toolRepository = new ToolRepository($app);
+
+                $tools = Config::get('mcp-server.tools', []);
+                $toolRepository->registerMany($tools);
+
+                return $toolRepository;
+            });
+
+            $this->app->singleton(MCPServer::class, function ($app) {
+                $transport = new SseTransport();
+
+                $adapterType = Config::get('mcp-server.sse_adapter', 'redis');
+                $adapterFactory = new SseAdapterFactory(adapterType: $adapterType);
+                $adapter = $adapterFactory->createAdapter();
+
+                $transport->setAdapter($adapter);
+
+                $protocol = new MCPProtocol($transport);
+
+                $serverInfo = Config::get('mcp-server.server');
+
+                $capabilities = new ServerCapabilities();
+
+                $toolRepository = app(ToolRepository::class);
+                $capabilities->withTools(['schemas' => $toolRepository->getToolSchemas()]);
+
+                return MCPServer::create(
+                    protocol: $protocol,
+                    name: $serverInfo['name'],
+                    version: $serverInfo['version'],
+                    capabilities: $capabilities
+                )->registerToolRepository(toolRepository: $toolRepository);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Streamable HTTP provider and controller
- register provider and routes based on config
- allow `streamable_http` as server provider option

## Testing
- `composer test` *(fails: vendor/bin/pest not found)*