### PR TITLE
Improve streamable HTTP test coverage

### DIFF
--- a/tests/Http/StreamableHttpTest.php
+++ b/tests/Http/StreamableHttpTest.php
@@ -1,0 +1,39 @@
+<?php
+
+test('streamable http GET returns method not allowed', function () {
+    $response = $this->get('/mcp');
+
+    $response->assertStatus(405)
+        ->assertJson([
+            'jsonrpc' => '2.0',
+            'error' => 'Method Not Allowed',
+        ]);
+});
+
+test('tool can be called via streamable http', function () {
+    $payload = [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'hello-world',
+            'arguments' => [
+                'name' => 'Tester',
+            ],
+        ],
+    ];
+
+    $response = $this->postJson('/mcp', $payload);
+
+    $response->assertStatus(200);
+    $data = $response->json();
+
+    expect($data['jsonrpc'])->toBe('2.0');
+    expect($data['id'])->toBe(1);
+    expect($data['result']['content'][0]['type'])->toBe('text');
+    expect($data['result']['content'][0]['text'])
+        ->toContain('HelloWorld `Tester` developer');
+
+    $decoded = json_decode($data['result']['content'][0]['text'], true);
+    expect($decoded['name'])->toBe('Tester');
+});


### PR DESCRIPTION
## Summary
- extend streamable HTTP test with extra assertions
- ensure tool output JSON structure is validated

## Testing
- `vendor/bin/pint`
- `vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_68418ddeda048321912cbd3decee6428