### PR TITLE
Add MCP integration tests to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,3 +47,14 @@ jobs:
 
       - name: Execute tests
         run: cd $GITHUB_WORKSPACE && vendor/bin/pest tests
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Run MCP integration tests
+        run: |
+          ./scripts/test-setup.sh
+          cd laravel-mcp-test
+          ./run-test.sh


### PR DESCRIPTION
## Summary
- update CI workflow to run scripts/test-setup.sh and run-test.sh

## Testing
- `vendor/bin/pest`
- `./scripts/test-setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841db86e80c8321b0ce341b16a1457a