### PR TITLE
Add MCP Sampling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,29 @@ This helps you rapidly develop and debug tools by:
 - Displaying formatted results or detailed error information
 - Supporting complex input types including objects and arrays
 
+### Requesting Sampling
+
+MCP servers can ask connected clients to perform language model sampling. Create
+sampler classes using:
+
+```bash
+php artisan make:mcp-sampler AskQuestion
+```
+
+This generates a class in `app/MCP/Samplers` extending the base `Sampler`. Use
+`SamplingService` to send `sampling/createMessage` requests to a client:
+
+```php
+use App\MCP\Samplers\AskQuestionSampler;
+use OPGG\LaravelMcpServer\Services\SamplingService\SamplingService;
+
+$sampler = new AskQuestionSampler;
+$result = app(SamplingService::class)->createMessage($clientId, $sampler);
+```
+
+The `$clientId` comes from the initialization handshake when using the SSE
+transport.
+
 ### Visualizing MCP Tools with Inspector
 
 You can also use the Model Context Protocol Inspector to visualize and test your MCP tools:

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -167,7 +167,8 @@ curl -X POST "$HTTP_ENDPOINT" \
       "protocolVersion": "2024-11-05",
       "capabilities": {
         "tools": {},
-        "resources": {}
+        "resources": {},
+        "sampling": {}
       },
       "clientInfo": {
         "name": "test-client",

--- a/src/Console/Commands/MakeMcpSamplerCommand.php
+++ b/src/Console/Commands/MakeMcpSamplerCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace OPGG\LaravelMcpServer\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+class MakeMcpSamplerCommand extends Command
+{
+    protected $signature = 'make:mcp-sampler {name : The name of the sampler}';
+
+    protected $description = 'Create a new MCP sampler class';
+
+    public function __construct(private Filesystem $files)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $className = $this->getClassName();
+        $path = $this->getPath($className);
+
+        if ($this->files->exists($path)) {
+            $this->error("❌ MCP sampler {$className} already exists!");
+
+            return 1;
+        }
+
+        $this->makeDirectory($path);
+        $stub = $this->files->get(__DIR__.'/../../stubs/sampler.stub');
+        $stub = str_replace(['{{ className }}', '{{ namespace }}'], [$className, 'App\\MCP\\Samplers'], $stub);
+        $this->files->put($path, $stub);
+        $this->info("✅ Created: {$path}");
+
+        return 0;
+    }
+
+    protected function getClassName(): string
+    {
+        $name = preg_replace('/[\s\-_]+/', ' ', trim($this->argument('name')));
+        $name = Str::studly($name);
+        if (! Str::endsWith($name, 'Sampler')) {
+            $name .= 'Sampler';
+        }
+
+        return $name;
+    }
+
+    protected function getPath(string $className): string
+    {
+        return app_path("MCP/Samplers/{$className}.php");
+    }
+
+    protected function makeDirectory(string $path): void
+    {
+        $dir = dirname($path);
+        if (! $this->files->isDirectory($dir)) {
+            $this->files->makeDirectory($dir, 0755, true, true);
+        }
+    }
+}

--- a/src/LaravelMcpServerServiceProvider.php
+++ b/src/LaravelMcpServerServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Route;
 use OPGG\LaravelMcpServer\Console\Commands\MakeMcpPromptCommand;
 use OPGG\LaravelMcpServer\Console\Commands\MakeMcpResourceCommand;
 use OPGG\LaravelMcpServer\Console\Commands\MakeMcpResourceTemplateCommand;
+use OPGG\LaravelMcpServer\Console\Commands\MakeMcpSamplerCommand;
 use OPGG\LaravelMcpServer\Console\Commands\MakeMcpToolCommand;
 use OPGG\LaravelMcpServer\Console\Commands\MigrateToolsCommand;
 use OPGG\LaravelMcpServer\Console\Commands\TestMcpToolCommand;
@@ -35,6 +36,7 @@ class LaravelMcpServerServiceProvider extends PackageServiceProvider
                 MakeMcpToolCommand::class,
                 MakeMcpResourceCommand::class,
                 MakeMcpResourceTemplateCommand::class,
+                MakeMcpSamplerCommand::class,
                 MakeMcpPromptCommand::class,
                 TestMcpToolCommand::class,
                 MigrateToolsCommand::class,

--- a/src/Providers/SseServiceProvider.php
+++ b/src/Providers/SseServiceProvider.php
@@ -9,6 +9,7 @@ use OPGG\LaravelMcpServer\Server\MCPServer;
 use OPGG\LaravelMcpServer\Server\ServerCapabilities;
 use OPGG\LaravelMcpServer\Services\PromptService\PromptRepository;
 use OPGG\LaravelMcpServer\Services\ResourceService\ResourceRepository;
+use OPGG\LaravelMcpServer\Services\SamplingService\SamplingService;
 use OPGG\LaravelMcpServer\Services\SseAdapterFactory;
 use OPGG\LaravelMcpServer\Services\ToolService\ToolRepository;
 use OPGG\LaravelMcpServer\Transports\SseTransport;
@@ -74,10 +75,16 @@ final class SseServiceProvider extends ServiceProvider
                     'prompts' => $promptRepository->getPromptSchemas(),
                 ]]);
 
+                $capabilities->withSampling();
+
                 return MCPServer::create(protocol: $protocol, name: $serverInfo['name'], version: $serverInfo['version'], capabilities: $capabilities)
                     ->registerToolRepository(toolRepository: $toolRepository)
                     ->registerResourceRepository(repository: $resourceRepository)
                     ->registerPromptRepository(repository: $promptRepository);
+            });
+
+            $this->app->singleton(SamplingService::class, function ($app) {
+                return new SamplingService(app(MCPServer::class));
             });
         }
     }

--- a/src/Providers/StreamableHttpServiceProvider.php
+++ b/src/Providers/StreamableHttpServiceProvider.php
@@ -9,6 +9,7 @@ use OPGG\LaravelMcpServer\Server\MCPServer;
 use OPGG\LaravelMcpServer\Server\ServerCapabilities;
 use OPGG\LaravelMcpServer\Services\PromptService\PromptRepository;
 use OPGG\LaravelMcpServer\Services\ResourceService\ResourceRepository;
+use OPGG\LaravelMcpServer\Services\SamplingService\SamplingService;
 use OPGG\LaravelMcpServer\Services\ToolService\ToolRepository;
 use OPGG\LaravelMcpServer\Transports\StreamableHttpTransport;
 
@@ -69,10 +70,16 @@ final class StreamableHttpServiceProvider extends ServiceProvider
                     'prompts' => $promptRepository->getPromptSchemas(),
                 ]]);
 
+                $capabilities->withSampling();
+
                 return MCPServer::create(protocol: $protocol, name: $serverInfo['name'], version: $serverInfo['version'], capabilities: $capabilities)
                     ->registerToolRepository(toolRepository: $toolRepository)
                     ->registerResourceRepository(repository: $resourceRepository)
                     ->registerPromptRepository(repository: $promptRepository);
+            });
+
+            $this->app->singleton(SamplingService::class, function ($app) {
+                return new SamplingService(app(MCPServer::class));
             });
         }
     }

--- a/src/Server/ServerCapabilities.php
+++ b/src/Server/ServerCapabilities.php
@@ -48,6 +48,10 @@ final class ServerCapabilities
      */
     private ?array $promptsConfig = null;
 
+    private bool $supportsSampling = false;
+
+    private ?array $samplingConfig = null;
+
     /**
      * Enables the tools capability for the server instance.
      * Allows specifying optional configuration details for the tools feature.
@@ -88,6 +92,14 @@ final class ServerCapabilities
         return $this;
     }
 
+    public function withSampling(?array $config = []): self
+    {
+        $this->supportsSampling = true;
+        $this->samplingConfig = $config;
+
+        return $this;
+    }
+
     /**
      * Converts the server capabilities configuration into an array format suitable for JSON serialization.
      * Only includes capabilities that are actively enabled.
@@ -110,6 +122,10 @@ final class ServerCapabilities
 
         if ($this->supportsPrompts) {
             $capabilities['prompts'] = $this->promptsConfig ?? new stdClass;
+        }
+
+        if ($this->supportsSampling) {
+            $capabilities['sampling'] = $this->samplingConfig ?? new stdClass;
         }
 
         return $capabilities;

--- a/src/Services/SamplingService/Sampler.php
+++ b/src/Services/SamplingService/Sampler.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace OPGG\LaravelMcpServer\Services\SamplingService;
+
+/**
+ * Base class describing a sampling request.
+ */
+abstract class Sampler
+{
+    /**
+     * Conversation messages for the sampling request.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $messages = [];
+
+    /**
+     * Optional model preference hints.
+     *
+     * @var array<string, mixed>|null
+     */
+    public ?array $modelPreferences = null;
+
+    /**
+     * Optional system prompt sent to the model.
+     */
+    public ?string $systemPrompt = null;
+
+    /**
+     * Optional maximum tokens parameter.
+     */
+    public ?int $maxTokens = null;
+
+    /**
+     * Convert the sampler to an array for the sampling/createMessage request.
+     */
+    public function toArray(): array
+    {
+        $data = ['messages' => $this->messages];
+
+        if ($this->modelPreferences !== null) {
+            $data['modelPreferences'] = $this->modelPreferences;
+        }
+        if ($this->systemPrompt !== null) {
+            $data['systemPrompt'] = $this->systemPrompt;
+        }
+        if ($this->maxTokens !== null) {
+            $data['maxTokens'] = $this->maxTokens;
+        }
+
+        return $data;
+    }
+}

--- a/src/Services/SamplingService/SamplingService.php
+++ b/src/Services/SamplingService/SamplingService.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace OPGG\LaravelMcpServer\Services\SamplingService;
+
+use Illuminate\Support\Str;
+use OPGG\LaravelMcpServer\Data\ProcessMessageData;
+use OPGG\LaravelMcpServer\Server\MCPServer;
+
+class SamplingService
+{
+    public function __construct(private MCPServer $server) {}
+
+    /**
+     * Request a language model generation from the connected client.
+     */
+    public function createMessage(string $clientId, Sampler|array $sampler): ProcessMessageData
+    {
+        $params = $sampler instanceof Sampler ? $sampler->toArray() : $sampler;
+
+        $message = [
+            'jsonrpc' => '2.0',
+            'id' => Str::uuid()->toString(),
+            'method' => 'sampling/createMessage',
+            'params' => $params,
+        ];
+
+        return $this->server->requestMessage(clientId: $clientId, message: $message);
+    }
+}

--- a/src/stubs/sampler.stub
+++ b/src/stubs/sampler.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace {{ namespace }};
+
+use OPGG\LaravelMcpServer\Services\SamplingService\Sampler;
+
+class {{ className }} extends Sampler
+{
+    public array $messages = [
+        [
+            'role' => 'user',
+            'content' => [
+                'type' => 'text',
+                'text' => 'Your message here',
+            ],
+        ],
+    ];
+}

--- a/tests/Console/Commands/MakeMcpSamplerCommandTest.php
+++ b/tests/Console/Commands/MakeMcpSamplerCommandTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+
+afterEach(function () {
+    File::deleteDirectory(app_path('MCP/Samplers'));
+});
+
+test('make:mcp-sampler generates a sampler class', function () {
+    $path = app_path('MCP/Samplers/TestSampler.php');
+
+    $this->artisan('make:mcp-sampler', ['name' => 'Test'])
+        ->expectsOutputToContain('Created')
+        ->assertExitCode(0);
+
+    expect(File::exists($path))->toBeTrue();
+});

--- a/tests/Services/SamplingService/SamplerTest.php
+++ b/tests/Services/SamplingService/SamplerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use OPGG\LaravelMcpServer\Services\SamplingService\Sampler;
+
+class SimpleSampler extends Sampler
+{
+    public array $messages = [
+        [
+            'role' => 'user',
+            'content' => [
+                'type' => 'text',
+                'text' => 'hi',
+            ],
+        ],
+    ];
+}
+
+test('sampler toArray filters null values', function () {
+    $sampler = new SimpleSampler;
+
+    expect($sampler->toArray())->toBe([
+        'messages' => $sampler->messages,
+    ]);
+});
+
+test('sampler includes optional fields', function () {
+    $sampler = new class extends Sampler
+    {
+        public array $messages = [];
+
+        public ?array $modelPreferences = ['hints' => [['name' => 'claude']]];
+
+        public ?string $systemPrompt = 'sys';
+
+        public ?int $maxTokens = 5;
+    };
+
+    expect($sampler->toArray())->toBe([
+        'messages' => [],
+        'modelPreferences' => ['hints' => [['name' => 'claude']]],
+        'systemPrompt' => 'sys',
+        'maxTokens' => 5,
+    ]);
+});


### PR DESCRIPTION
## Summary
- support sampling capability in ServerCapabilities
- provide SamplingService and Sampler base class
- add `make:mcp-sampler` command
- register service and capability in providers
- document sampling in README
- update test setup to include sampling capability
- add tests for new sampler command and class

## Testing
- `vendor/bin/pint`
- `vendor/bin/phpstan analyse`
- `vendor/bin/pest`
- `./scripts/test-setup.sh`
- `cd laravel-mcp-test && ./run-test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842aeeb45048321a65e1009917e1a84