### PR TITLE
[docs] fix missing end tags for code

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ public function annotations(): array
         'requires_permission' => 'analytics.read',
     ];
 }
+```
 
 ### Working with Resources
 


### PR DESCRIPTION
The `Working with Resources` bit was showing incorrect. This PR fixes the readme styling.