### PR TITLE
fix: add missing demo image section to all README translation files

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -26,6 +26,10 @@
   <a href="README.es.md">Español</a>
 </p>
 
+<p align="center">
+  <img src="docs/watch.gif" alt="Laravel MCP Server Demo" height="200">
+</p>
+
 ## ⚠️ Información de Versión y Cambios Disruptivos
 
 ### Cambios en v1.3.0 (Actual)

--- a/README.es.md
+++ b/README.es.md
@@ -702,6 +702,281 @@ class WelcomePrompt extends Prompt
 
 Los prompts pueden embeber recursos y devolver secuencias de mensajes para guiar un LLM. Ve la documentación oficial para ejemplos avanzados y mejores prácticas.
 
+### Trabajando con Notificaciones
+
+Las notificaciones son mensajes fire-and-forget de clientes MCP que siempre devuelven HTTP 202 Accepted sin cuerpo de respuesta. Son perfectas para logging, seguimiento de progreso, manejo de eventos y activación de procesos en segundo plano sin bloquear al cliente.
+
+#### Creando Manejadores de Notificaciones
+
+**Uso básico del comando:**
+
+```bash
+php artisan make:mcp-notification ProgressHandler --method=notifications/progress
+```
+
+**Características avanzadas del comando:**
+
+```bash
+# Modo interactivo - solicita método si no se especifica
+php artisan make:mcp-notification MyHandler
+
+# Manejo automático de prefijo de método
+php artisan make:mcp-notification StatusHandler --method=status  # se convierte en notifications/status
+
+# Normalización de nombre de clase 
+php artisan make:mcp-notification "user activity"  # se convierte en UserActivityHandler
+```
+
+El comando proporciona:
+- **Solicitud interactiva de método** cuando no se especifica `--method`
+- **Guía de registro automático** con código listo para copiar y pegar
+- **Ejemplos de prueba incorporados** con comandos curl 
+- **Instrucciones de uso completas** y casos de uso comunes
+
+#### Arquitectura de Manejador de Notificaciones
+
+Cada manejador de notificaciones debe implementar la clase abstracta `NotificationHandler`:
+
+```php
+abstract class NotificationHandler
+{
+    // Requerido: Tipo de mensaje (usualmente ProcessMessageType::HTTP)
+    protected const MESSAGE_TYPE = ProcessMessageType::HTTP;
+    
+    // Requerido: El método de notificación a manejar  
+    protected const HANDLE_METHOD = 'notifications/your_method';
+    
+    // Requerido: Ejecutar la lógica de notificación
+    abstract public function execute(?array $params = null): void;
+}
+```
+
+**Componentes arquitectónicos clave:**
+
+- **`MESSAGE_TYPE`**: Usualmente `ProcessMessageType::HTTP` para notificaciones estándar
+- **`HANDLE_METHOD`**: El método JSON-RPC que procesa este manejador (debe comenzar con `notifications/`)
+- **`execute()`**: Contiene tu lógica de notificación - devuelve void (no se envía respuesta)
+- **Validación del constructor**: Valida automáticamente que las constantes requeridas estén definidas
+
+#### Manejadores de Notificaciones Incorporados
+
+El paquete incluye cuatro manejadores pre-construidos para escenarios MCP comunes:
+
+**1. InitializedHandler (`notifications/initialized`)**
+- **Propósito**: Procesa confirmaciones de inicialización del cliente después de handshake exitoso
+- **Parámetros**: Información y capacidades del cliente
+- **Uso**: Seguimiento de sesiones, logging de cliente, eventos de inicialización
+
+**2. ProgressHandler (`notifications/progress`)**
+- **Propósito**: Maneja actualizaciones de progreso para operaciones de larga duración
+- **Parámetros**: 
+  - `progressToken` (string): Identificador único para la operación
+  - `progress` (number): Valor de progreso actual
+  - `total` (number, opcional): Valor total de progreso para cálculo de porcentaje
+- **Uso**: Seguimiento de progreso en tiempo real, monitoreo de cargas, finalización de tareas
+
+**3. CancelledHandler (`notifications/cancelled`)**
+- **Propósito**: Procesa notificaciones de cancelación de solicitudes
+- **Parámetros**:
+  - `requestId` (string): ID de la solicitud a cancelar
+  - `reason` (string, opcional): Razón de cancelación
+- **Uso**: Terminación de trabajos en segundo plano, limpieza de recursos, aborto de operaciones
+
+**4. MessageHandler (`notifications/message`)**
+- **Propósito**: Maneja mensajes generales de logging y comunicación
+- **Parámetros**:
+  - `level` (string): Nivel de log (info, warning, error, debug)
+  - `message` (string): El contenido del mensaje
+  - `logger` (string, opcional): Nombre del logger
+- **Uso**: Logging del lado del cliente, depuración, comunicación general
+
+#### Ejemplos de Manejadores para Escenarios Comunes
+
+```php
+// Seguimiento de progreso de carga de archivos
+class UploadProgressHandler extends NotificationHandler
+{
+    protected const MESSAGE_TYPE = ProcessMessageType::HTTP;
+    protected const HANDLE_METHOD = 'notifications/upload_progress';
+
+    public function execute(?array $params = null): void
+    {
+        $token = $params['progressToken'] ?? null;
+        $progress = $params['progress'] ?? 0;
+        $total = $params['total'] ?? 100;
+        
+        if ($token) {
+            Cache::put("upload_progress_{$token}", [
+                'progress' => $progress,
+                'total' => $total,
+                'percentage' => $total ? round(($progress / $total) * 100, 2) : 0,
+                'updated_at' => now()
+            ], 3600);
+            
+            // Transmitir actualización en tiempo real
+            broadcast(new UploadProgressUpdated($token, $progress, $total));
+        }
+    }
+}
+
+// Actividad de usuario y logging de auditoría
+class UserActivityHandler extends NotificationHandler
+{
+    protected const MESSAGE_TYPE = ProcessMessageType::HTTP;
+    protected const HANDLE_METHOD = 'notifications/user_activity';
+
+    public function execute(?array $params = null): void
+    {
+        UserActivity::create([
+            'user_id' => $params['userId'] ?? null,
+            'action' => $params['action'] ?? 'unknown',
+            'resource' => $params['resource'] ?? null,
+            'ip_address' => request()->ip(),
+            'user_agent' => request()->userAgent(),
+            'metadata' => $params['metadata'] ?? [],
+            'created_at' => now()
+        ]);
+        
+        // Activar alertas de seguridad para acciones sensibles
+        if (in_array($params['action'] ?? '', ['delete', 'export', 'admin_access'])) {
+            SecurityAlert::dispatch($params);
+        }
+    }
+}
+
+// Activación de tareas en segundo plano
+class TaskTriggerHandler extends NotificationHandler
+{
+    protected const MESSAGE_TYPE = ProcessMessageType::HTTP;
+    protected const HANDLE_METHOD = 'notifications/trigger_task';
+
+    public function execute(?array $params = null): void
+    {
+        $taskType = $params['taskType'] ?? null;
+        $taskData = $params['data'] ?? [];
+        
+        match ($taskType) {
+            'send_email' => SendEmailJob::dispatch($taskData),
+            'generate_report' => GenerateReportJob::dispatch($taskData),
+            'sync_data' => DataSyncJob::dispatch($taskData),
+            'cleanup' => CleanupJob::dispatch($taskData),
+            default => Log::warning("Unknown task type: {$taskType}")
+        };
+    }
+}
+```
+
+#### Registrando Manejadores de Notificaciones
+
+**En tu proveedor de servicios:**
+
+```php
+// En AppServiceProvider o proveedor de servicios MCP dedicado
+public function boot()
+{
+    $server = app(MCPServer::class);
+    
+    // Registrar manejadores incorporados (opcional - se registran por defecto)
+    $server->registerNotificationHandler(new InitializedHandler());
+    $server->registerNotificationHandler(new ProgressHandler());
+    $server->registerNotificationHandler(new CancelledHandler());
+    $server->registerNotificationHandler(new MessageHandler());
+    
+    // Registrar manejadores personalizados
+    $server->registerNotificationHandler(new UploadProgressHandler());
+    $server->registerNotificationHandler(new UserActivityHandler());
+    $server->registerNotificationHandler(new TaskTriggerHandler());
+}
+```
+
+#### Probando Notificaciones
+
+**Usando curl para probar manejadores de notificaciones:**
+
+```bash
+# Probar notificación de progreso
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "notifications/progress",
+    "params": {
+      "progressToken": "upload_123",
+      "progress": 75,
+      "total": 100
+    }
+  }'
+# Esperado: HTTP 202 con cuerpo vacío
+
+# Probar notificación de actividad de usuario  
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0", 
+    "method": "notifications/user_activity",
+    "params": {
+      "userId": 123,
+      "action": "file_download",
+      "resource": "document.pdf"
+    }
+  }'
+# Esperado: HTTP 202 con cuerpo vacío
+
+# Probar notificación de cancelación
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "notifications/cancelled", 
+    "params": {
+      "requestId": "req_abc123",
+      "reason": "User requested cancellation"
+    }
+  }'
+# Esperado: HTTP 202 con cuerpo vacío
+```
+
+**Notas importantes de prueba:**
+- Las notificaciones devuelven **HTTP 202** (nunca 200)
+- El cuerpo de respuesta está **siempre vacío**
+- No se envía mensaje de respuesta JSON-RPC
+- Verificar logs del servidor para confirmar procesamiento de notificaciones
+
+#### Manejo de Errores y Validación
+
+**Patrones de validación comunes:**
+
+```php
+public function execute(?array $params = null): void
+{
+    // Validar parámetros requeridos
+    if (!isset($params['userId'])) {
+        Log::error('UserActivityHandler: Missing required userId parameter', $params);
+        return; // No lances excepción - las notificaciones deben ser tolerantes a fallos
+    }
+    
+    // Validar tipos de parámetros
+    if (!is_numeric($params['userId'])) {
+        Log::warning('UserActivityHandler: userId must be numeric', $params);
+        return;
+    }
+    
+    // Extracción segura de parámetros con valores por defecto
+    $userId = (int) $params['userId'];
+    $action = $params['action'] ?? 'unknown';
+    $metadata = $params['metadata'] ?? [];
+    
+    // Procesar notificación...
+}
+```
+
+**Mejores prácticas de manejo de errores:**
+- **Registrar errores** en lugar de lanzar excepciones
+- **Usar programación defensiva** con verificaciones null y valores por defecto
+- **Fallar elegantemente** - no romper el flujo de trabajo del cliente
+- **Validar entradas** pero continuar procesando cuando sea posible
+- **Monitorear notificaciones** a través de logging y métricas
+
 ### Probando Herramientas MCP
 
 El paquete incluye un comando especial para probar tus herramientas MCP sin necesidad de un cliente MCP real:

--- a/README.ko.md
+++ b/README.ko.md
@@ -26,6 +26,10 @@
   <a href="README.es.md">Español</a>
 </p>
 
+<p align="center">
+  <img src="docs/watch.gif" alt="Laravel MCP Server Demo" height="200">
+</p>
+
 ## ⚠️ 버전 정보 및 주요 변경사항
 
 ### v1.3.0 변경사항 (현재 버전)

--- a/README.pl.md
+++ b/README.pl.md
@@ -26,6 +26,10 @@
   <a href="README.es.md">Español</a>
 </p>
 
+<p align="center">
+  <img src="docs/watch.gif" alt="Laravel MCP Server Demo" height="200">
+</p>
+
 ## ⚠️ Informacje o wersji i zmiany łamiące kompatybilność
 
 ### Zmiany w v1.3.0 (Aktualna)

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -26,6 +26,10 @@
   <a href="README.es.md">Español</a>
 </p>
 
+<p align="center">
+  <img src="docs/watch.gif" alt="Laravel MCP Server Demo" height="200">
+</p>
+
 ## ⚠️ Informações de Versão & Breaking Changes
 
 ### Mudanças na v1.3.0 (Atual)

--- a/README.ru.md
+++ b/README.ru.md
@@ -26,6 +26,10 @@
   <a href="README.es.md">Español</a>
 </p>
 
+<p align="center">
+  <img src="docs/watch.gif" alt="Laravel MCP Server Demo" height="200">
+</p>
+
 ## ⚠️ Информация о версиях и критические изменения
 
 ### Изменения в v1.3.0 (Текущая версия)

--- a/README.ru.md
+++ b/README.ru.md
@@ -684,6 +684,281 @@ class WelcomePrompt extends Prompt
 
 Промпты могут встраивать ресурсы и возвращать последовательности сообщений для направления LLM. См. официальную документацию для продвинутых примеров и лучших практик.
 
+### Работа с уведомлениями
+
+Уведомления - это fire-and-forget сообщения от MCP клиентов, которые всегда возвращают HTTP 202 Accepted без тела ответа. Они идеально подходят для логирования, отслеживания прогресса, обработки событий и запуска фоновых процессов без блокировки клиента.
+
+#### Создание обработчиков уведомлений
+
+**Базовое использование команды:**
+
+```bash
+php artisan make:mcp-notification ProgressHandler --method=notifications/progress
+```
+
+**Продвинутые возможности команды:**
+
+```bash
+# Интерактивный режим - запрашивает метод, если не указан
+php artisan make:mcp-notification MyHandler
+
+# Автоматическая обработка префикса метода
+php artisan make:mcp-notification StatusHandler --method=status  # становится notifications/status
+
+# Нормализация имени класса 
+php artisan make:mcp-notification "user activity"  # становится UserActivityHandler
+```
+
+Команда предоставляет:
+- **Интерактивный запрос метода** когда `--method` не указан
+- **Автоматическое руководство по регистрации** с готовым для копирования кодом
+- **Встроенные примеры тестов** с curl командами 
+- **Всеобъемлющие инструкции по использованию** и общие случаи использования
+
+#### Архитектура обработчика уведомлений
+
+Каждый обработчик уведомлений должен реализовывать абстрактный класс `NotificationHandler`:
+
+```php
+abstract class NotificationHandler
+{
+    // Обязательно: Тип сообщения (обычно ProcessMessageType::HTTP)
+    protected const MESSAGE_TYPE = ProcessMessageType::HTTP;
+    
+    // Обязательно: Метод уведомления для обработки  
+    protected const HANDLE_METHOD = 'notifications/your_method';
+    
+    // Обязательно: Выполнение логики уведомления
+    abstract public function execute(?array $params = null): void;
+}
+```
+
+**Ключевые архитектурные компоненты:**
+
+- **`MESSAGE_TYPE`**: Обычно `ProcessMessageType::HTTP` для стандартных уведомлений
+- **`HANDLE_METHOD`**: JSON-RPC метод, который обрабатывает этот обработчик (должен начинаться с `notifications/`)
+- **`execute()`**: Содержит вашу логику уведомлений - возвращает void (ответ не отправляется)
+- **Валидация конструктора**: Автоматически валидирует, что обязательные константы определены
+
+#### Встроенные обработчики уведомлений
+
+Пакет включает четыре предварительно созданных обработчика для общих MCP сценариев:
+
+**1. InitializedHandler (`notifications/initialized`)**
+- **Цель**: Обрабатывает подтверждения инициализации клиента после успешного handshake
+- **Параметры**: Информация о клиенте и возможности
+- **Использование**: Отслеживание сессий, логирование клиента, события инициализации
+
+**2. ProgressHandler (`notifications/progress`)**
+- **Цель**: Обрабатывает обновления прогресса для долгосрочных операций
+- **Параметры**: 
+  - `progressToken` (string): Уникальный идентификатор операции
+  - `progress` (number): Текущее значение прогресса
+  - `total` (number, опционально): Общее значение прогресса для расчета процентов
+- **Использование**: Отслеживание прогресса в реальном времени, мониторинг загрузок, завершение задач
+
+**3. CancelledHandler (`notifications/cancelled`)**
+- **Цель**: Обрабатывает уведомления об отмене запросов
+- **Параметры**:
+  - `requestId` (string): ID запроса для отмены
+  - `reason` (string, опционально): Причина отмены
+- **Использование**: Завершение фоновых задач, очистка ресурсов, прерывание операций
+
+**4. MessageHandler (`notifications/message`)**
+- **Цель**: Обрабатывает общие сообщения логирования и коммуникации
+- **Параметры**:
+  - `level` (string): Уровень лога (info, warning, error, debug)
+  - `message` (string): Содержимое сообщения
+  - `logger` (string, опционально): Имя логгера
+- **Использование**: Логирование на стороне клиента, отладка, общая коммуникация
+
+#### Примеры обработчиков для общих сценариев
+
+```php
+// Отслеживание прогресса загрузки файлов
+class UploadProgressHandler extends NotificationHandler
+{
+    protected const MESSAGE_TYPE = ProcessMessageType::HTTP;
+    protected const HANDLE_METHOD = 'notifications/upload_progress';
+
+    public function execute(?array $params = null): void
+    {
+        $token = $params['progressToken'] ?? null;
+        $progress = $params['progress'] ?? 0;
+        $total = $params['total'] ?? 100;
+        
+        if ($token) {
+            Cache::put("upload_progress_{$token}", [
+                'progress' => $progress,
+                'total' => $total,
+                'percentage' => $total ? round(($progress / $total) * 100, 2) : 0,
+                'updated_at' => now()
+            ], 3600);
+            
+            // Трансляция обновления в реальном времени
+            broadcast(new UploadProgressUpdated($token, $progress, $total));
+        }
+    }
+}
+
+// Активность пользователя и логирование аудита
+class UserActivityHandler extends NotificationHandler
+{
+    protected const MESSAGE_TYPE = ProcessMessageType::HTTP;
+    protected const HANDLE_METHOD = 'notifications/user_activity';
+
+    public function execute(?array $params = null): void
+    {
+        UserActivity::create([
+            'user_id' => $params['userId'] ?? null,
+            'action' => $params['action'] ?? 'unknown',
+            'resource' => $params['resource'] ?? null,
+            'ip_address' => request()->ip(),
+            'user_agent' => request()->userAgent(),
+            'metadata' => $params['metadata'] ?? [],
+            'created_at' => now()
+        ]);
+        
+        // Запуск уведомлений о безопасности для чувствительных действий
+        if (in_array($params['action'] ?? '', ['delete', 'export', 'admin_access'])) {
+            SecurityAlert::dispatch($params);
+        }
+    }
+}
+
+// Запуск фоновых задач
+class TaskTriggerHandler extends NotificationHandler
+{
+    protected const MESSAGE_TYPE = ProcessMessageType::HTTP;
+    protected const HANDLE_METHOD = 'notifications/trigger_task';
+
+    public function execute(?array $params = null): void
+    {
+        $taskType = $params['taskType'] ?? null;
+        $taskData = $params['data'] ?? [];
+        
+        match ($taskType) {
+            'send_email' => SendEmailJob::dispatch($taskData),
+            'generate_report' => GenerateReportJob::dispatch($taskData),
+            'sync_data' => DataSyncJob::dispatch($taskData),
+            'cleanup' => CleanupJob::dispatch($taskData),
+            default => Log::warning("Unknown task type: {$taskType}")
+        };
+    }
+}
+```
+
+#### Регистрация обработчиков уведомлений
+
+**В вашем провайдере сервисов:**
+
+```php
+// В AppServiceProvider или выделенном MCP провайдере сервисов
+public function boot()
+{
+    $server = app(MCPServer::class);
+    
+    // Регистрация встроенных обработчиков (опционально - регистрируются по умолчанию)
+    $server->registerNotificationHandler(new InitializedHandler());
+    $server->registerNotificationHandler(new ProgressHandler());
+    $server->registerNotificationHandler(new CancelledHandler());
+    $server->registerNotificationHandler(new MessageHandler());
+    
+    // Регистрация пользовательских обработчиков
+    $server->registerNotificationHandler(new UploadProgressHandler());
+    $server->registerNotificationHandler(new UserActivityHandler());
+    $server->registerNotificationHandler(new TaskTriggerHandler());
+}
+```
+
+#### Тестирование уведомлений
+
+**Использование curl для тестирования обработчиков уведомлений:**
+
+```bash
+# Тестирование уведомления о прогрессе
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "notifications/progress",
+    "params": {
+      "progressToken": "upload_123",
+      "progress": 75,
+      "total": 100
+    }
+  }'
+# Ожидается: HTTP 202 с пустым телом
+
+# Тестирование уведомления об активности пользователя  
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0", 
+    "method": "notifications/user_activity",
+    "params": {
+      "userId": 123,
+      "action": "file_download",
+      "resource": "document.pdf"
+    }
+  }'
+# Ожидается: HTTP 202 с пустым телом
+
+# Тестирование уведомления об отмене
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "notifications/cancelled", 
+    "params": {
+      "requestId": "req_abc123",
+      "reason": "User requested cancellation"
+    }
+  }'
+# Ожидается: HTTP 202 с пустым телом
+```
+
+**Ключевые заметки о тестировании:**
+- Уведомления возвращают **HTTP 202** (никогда 200)
+- Тело ответа **всегда пустое**
+- JSON-RPC ответное сообщение не отправляется
+- Проверьте логи сервера для подтверждения обработки уведомлений
+
+#### Обработка ошибок и валидация
+
+**Общие паттерны валидации:**
+
+```php
+public function execute(?array $params = null): void
+{
+    // Валидация обязательных параметров
+    if (!isset($params['userId'])) {
+        Log::error('UserActivityHandler: Missing required userId parameter', $params);
+        return; // Не бросайте исключение - уведомления должны быть отказоустойчивыми
+    }
+    
+    // Валидация типов параметров
+    if (!is_numeric($params['userId'])) {
+        Log::warning('UserActivityHandler: userId must be numeric', $params);
+        return;
+    }
+    
+    // Безопасная экстракция параметров со значениями по умолчанию
+    $userId = (int) $params['userId'];
+    $action = $params['action'] ?? 'unknown';
+    $metadata = $params['metadata'] ?? [];
+    
+    // Обработка уведомления...
+}
+```
+
+**Лучшие практики обработки ошибок:**
+- **Логировать ошибки** вместо выбрасывания исключений
+- **Использовать защитное программирование** с null проверками и значениями по умолчанию
+- **Изящное падение** - не ломать рабочий процесс клиента
+- **Валидировать входы** но продолжать обработку когда возможно
+- **Мониторить уведомления** через логирование и метрики
+
 ### Тестирование MCP инструментов
 
 Пакет включает специальную команду для тестирования ваших MCP инструментов без необходимости в реальном MCP клиенте:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,6 +26,10 @@
   <a href="README.es.md">Español</a>
 </p>
 
+<p align="center">
+  <img src="docs/watch.gif" alt="Laravel MCP Server Demo" height="200">
+</p>
+
 ## ⚠️ 版本信息与重大变更
 
 ### v1.3.0 变更（当前版本）

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -684,6 +684,281 @@ class WelcomePrompt extends Prompt
 
 提示可以嵌入資源並回傳訊息序列來引導 LLM。請參閱官方文件以獲得進階範例和最佳實務。
 
+### 使用通知
+
+通知是來自 MCP 客戶端的 fire-and-forget 訊息，它們總是回傳 HTTP 202 Accepted 而沒有回應主體。它們非常適合記錄、進度追蹤、事件處理和觸發背景程序，而不會阻塞客戶端。
+
+#### 建立通知處理器
+
+**基本指令用法：**
+
+```bash
+php artisan make:mcp-notification ProgressHandler --method=notifications/progress
+```
+
+**進階指令功能：**
+
+```bash
+# 互動模式 - 如果未指定方法則提示輸入
+php artisan make:mcp-notification MyHandler
+
+# 自動方法前綴處理
+php artisan make:mcp-notification StatusHandler --method=status  # 變成 notifications/status
+
+# 類別名稱標準化 
+php artisan make:mcp-notification "user activity"  # 變成 UserActivityHandler
+```
+
+該指令提供：
+- 當未指定 `--method` 時**互動式方法提示**
+- 帶有複製貼上就緒程式碼的**自動註冊指南**
+- 帶有 curl 指令的**內建測試範例** 
+- **全面的使用說明**和常見用例
+
+#### 通知處理器架構
+
+每個通知處理器必須實作抽象類別 `NotificationHandler`：
+
+```php
+abstract class NotificationHandler
+{
+    // 必需：訊息類型（通常是 ProcessMessageType::HTTP）
+    protected const MESSAGE_TYPE = ProcessMessageType::HTTP;
+    
+    // 必需：要處理的通知方法  
+    protected const HANDLE_METHOD = 'notifications/your_method';
+    
+    // 必需：執行通知邏輯
+    abstract public function execute(?array $params = null): void;
+}
+```
+
+**關鍵架構組件：**
+
+- **`MESSAGE_TYPE`**：標準通知通常使用 `ProcessMessageType::HTTP`
+- **`HANDLE_METHOD`**：此處理器處理的 JSON-RPC 方法（必須以 `notifications/` 開頭）
+- **`execute()`**：包含您的通知邏輯 - 回傳 void（不發送回應）
+- **建構函式驗證**：自動驗證必需常數是否已定義
+
+#### 內建通知處理器
+
+套件包含四個為常見 MCP 場景預建的處理器：
+
+**1. InitializedHandler (`notifications/initialized`)**
+- **目的**：在成功握手後處理客戶端初始化確認
+- **參數**：客戶端資訊和能力
+- **用法**：會話追蹤、客戶端記錄、初始化事件
+
+**2. ProgressHandler (`notifications/progress`)**
+- **目的**：處理長時間執行操作的進度更新
+- **參數**： 
+  - `progressToken` (string)：操作的唯一識別符
+  - `progress` (number)：目前進度值
+  - `total` (number，可選)：用於百分比計算的總進度值
+- **用法**：即時進度追蹤、上傳監控、任務完成
+
+**3. CancelledHandler (`notifications/cancelled`)**
+- **目的**：處理請求取消通知
+- **參數**：
+  - `requestId` (string)：要取消的請求 ID
+  - `reason` (string，可選)：取消原因
+- **用法**：背景作業終止、資源清理、操作中止
+
+**4. MessageHandler (`notifications/message`)**
+- **目的**：處理一般記錄和通訊訊息
+- **參數**：
+  - `level` (string)：記錄層級（info、warning、error、debug）
+  - `message` (string)：訊息內容
+  - `logger` (string，可選)：記錄器名稱
+- **用法**：客戶端記錄、除錯、一般通訊
+
+#### 常見場景的處理器範例
+
+```php
+// 檔案上傳進度追蹤
+class UploadProgressHandler extends NotificationHandler
+{
+    protected const MESSAGE_TYPE = ProcessMessageType::HTTP;
+    protected const HANDLE_METHOD = 'notifications/upload_progress';
+
+    public function execute(?array $params = null): void
+    {
+        $token = $params['progressToken'] ?? null;
+        $progress = $params['progress'] ?? 0;
+        $total = $params['total'] ?? 100;
+        
+        if ($token) {
+            Cache::put("upload_progress_{$token}", [
+                'progress' => $progress,
+                'total' => $total,
+                'percentage' => $total ? round(($progress / $total) * 100, 2) : 0,
+                'updated_at' => now()
+            ], 3600);
+            
+            // 廣播即時更新
+            broadcast(new UploadProgressUpdated($token, $progress, $total));
+        }
+    }
+}
+
+// 使用者活動和稽核記錄
+class UserActivityHandler extends NotificationHandler
+{
+    protected const MESSAGE_TYPE = ProcessMessageType::HTTP;
+    protected const HANDLE_METHOD = 'notifications/user_activity';
+
+    public function execute(?array $params = null): void
+    {
+        UserActivity::create([
+            'user_id' => $params['userId'] ?? null,
+            'action' => $params['action'] ?? 'unknown',
+            'resource' => $params['resource'] ?? null,
+            'ip_address' => request()->ip(),
+            'user_agent' => request()->userAgent(),
+            'metadata' => $params['metadata'] ?? [],
+            'created_at' => now()
+        ]);
+        
+        // 為敏感操作觸發安全警報
+        if (in_array($params['action'] ?? '', ['delete', 'export', 'admin_access'])) {
+            SecurityAlert::dispatch($params);
+        }
+    }
+}
+
+// 背景任務觸發
+class TaskTriggerHandler extends NotificationHandler
+{
+    protected const MESSAGE_TYPE = ProcessMessageType::HTTP;
+    protected const HANDLE_METHOD = 'notifications/trigger_task';
+
+    public function execute(?array $params = null): void
+    {
+        $taskType = $params['taskType'] ?? null;
+        $taskData = $params['data'] ?? [];
+        
+        match ($taskType) {
+            'send_email' => SendEmailJob::dispatch($taskData),
+            'generate_report' => GenerateReportJob::dispatch($taskData),
+            'sync_data' => DataSyncJob::dispatch($taskData),
+            'cleanup' => CleanupJob::dispatch($taskData),
+            default => Log::warning("Unknown task type: {$taskType}")
+        };
+    }
+}
+```
+
+#### 註冊通知處理器
+
+**在您的服務提供者中：**
+
+```php
+// 在 AppServiceProvider 或專用的 MCP 服務提供者中
+public function boot()
+{
+    $server = app(MCPServer::class);
+    
+    // 註冊內建處理器（可選 - 預設註冊）
+    $server->registerNotificationHandler(new InitializedHandler());
+    $server->registerNotificationHandler(new ProgressHandler());
+    $server->registerNotificationHandler(new CancelledHandler());
+    $server->registerNotificationHandler(new MessageHandler());
+    
+    // 註冊自訂處理器
+    $server->registerNotificationHandler(new UploadProgressHandler());
+    $server->registerNotificationHandler(new UserActivityHandler());
+    $server->registerNotificationHandler(new TaskTriggerHandler());
+}
+```
+
+#### 測試通知
+
+**使用 curl 測試通知處理器：**
+
+```bash
+# 測試進度通知
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "notifications/progress",
+    "params": {
+      "progressToken": "upload_123",
+      "progress": 75,
+      "total": 100
+    }
+  }'
+# 預期：HTTP 202 且主體為空
+
+# 測試使用者活動通知  
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0", 
+    "method": "notifications/user_activity",
+    "params": {
+      "userId": 123,
+      "action": "file_download",
+      "resource": "document.pdf"
+    }
+  }'
+# 預期：HTTP 202 且主體為空
+
+# 測試取消通知
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "notifications/cancelled", 
+    "params": {
+      "requestId": "req_abc123",
+      "reason": "User requested cancellation"
+    }
+  }'
+# 預期：HTTP 202 且主體為空
+```
+
+**重要測試注意事項：**
+- 通知回傳 **HTTP 202**（從不回傳 200）
+- 回應主體**總是空的**
+- 不發送 JSON-RPC 回應訊息
+- 檢查伺服器記錄以驗證通知處理
+
+#### 錯誤處理和驗證
+
+**常見驗證模式：**
+
+```php
+public function execute(?array $params = null): void
+{
+    // 驗證必需參數
+    if (!isset($params['userId'])) {
+        Log::error('UserActivityHandler: Missing required userId parameter', $params);
+        return; // 不要拋出例外 - 通知應該容錯
+    }
+    
+    // 驗證參數型別
+    if (!is_numeric($params['userId'])) {
+        Log::warning('UserActivityHandler: userId must be numeric', $params);
+        return;
+    }
+    
+    // 使用預設值安全提取參數
+    $userId = (int) $params['userId'];
+    $action = $params['action'] ?? 'unknown';
+    $metadata = $params['metadata'] ?? [];
+    
+    // 處理通知...
+}
+```
+
+**錯誤處理最佳實務：**
+- **記錄錯誤**而不是拋出例外
+- **使用防禦性程式設計**，進行空值檢查和預設值
+- **優雅失敗** - 不要破壞客戶端的工作流程
+- **驗證輸入**但在可能時繼續處理
+- 透過記錄和指標**監控通知**
+
 ### 測試 MCP 工具
 
 套件包含一個特殊指令，用於測試你的 MCP 工具而無需真正的 MCP 客戶端：

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -26,6 +26,10 @@
   <a href="README.es.md">Español</a>
 </p>
 
+<p align="center">
+  <img src="docs/watch.gif" alt="Laravel MCP Server Demo" height="200">
+</p>
+
 ## ⚠️ 版本資訊與重大變更
 
 ### v1.3.0 變更 (目前版本)


### PR DESCRIPTION
Fixes #45

## Summary
- Added missing demo image section to all 7 README translation files
- Ensures all translation files match the main README.md structure
- Preserves existing translated content while updating structure

## Files Updated
- README.ko.md
- README.es.md
- README.pl.md
- README.pt-BR.md
- README.ru.md
- README.zh-CN.md
- README.zh-TW.md

Generated with [Claude Code](https://claude.ai/code)