### PR TITLE
fix: change InitializedHandler logging from info to debug level

### DIFF
--- a/src/Server/Notification/InitializedHandler.php
+++ b/src/Server/Notification/InitializedHandler.php
@@ -23,7 +23,7 @@ class InitializedHandler extends NotificationHandler
         // - Triggering initialization events
         // - Recording session start times
 
-        Log::info('MCP Client Initialized', [
+        Log::debug('MCP Client Initialized', [
             'params' => $params,
             'initialized_at' => now()->toISOString(),
         ]);


### PR DESCRIPTION
This PR fixes the excessive logging issue reported in issue #50.

## Changes
- Changed `Log::info` to `Log::debug` in InitializedHandler.php:26
- Prevents excessive log entries in production environments
- Client initialization events will now only log in debug mode
- Resolves production storage and performance concerns

Fixes #50

Generated with [Claude Code](https://claude.ai/code)