### PR TITLE
feat: add dynamic tool filtering by query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,75 @@ curl -X POST http://localhost:8000/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
+### Dynamic Tool Filtering by Query String
+
+If one endpoint needs to expose different tool sets based on the incoming URL, attach a dynamic tools resolver to the route.
+The resolver owns both the declared tool catalog for the endpoint and the per-request visible subset.
+
+```php
+use OPGG\LaravelMcpServer\Data\ToolResolutionContext;
+use OPGG\LaravelMcpServer\Routing\McpEndpointDefinition;
+use OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface;
+
+final class LolPhaseToolResolver implements DynamicToolResolverInterface
+{
+    public function declaredTools(McpEndpointDefinition $endpoint): array
+    {
+        return [
+            \App\MCP\Tools\LolSearchChampionMetaTool::class,
+            \App\MCP\Tools\LolGetChampionAnalysisTool::class,
+            \App\MCP\Tools\LolGetLiveItemRecommendationsTool::class,
+        ];
+    }
+
+    public function resolve(
+        McpEndpointDefinition $endpoint,
+        ToolResolutionContext $context,
+    ): array {
+        return match ($context->queryParameters['phase'] ?? null) {
+            'lobby' => [
+                \App\MCP\Tools\LolSearchChampionMetaTool::class,
+                \App\MCP\Tools\LolGetChampionAnalysisTool::class,
+            ],
+            'inprogress' => [
+                \App\MCP\Tools\LolGetLiveItemRecommendationsTool::class,
+            ],
+            default => $this->declaredTools($endpoint),
+        };
+    }
+
+    public function consumedQueryParameters(): array
+    {
+        return ['phase'];
+    }
+}
+```
+
+```php
+Route::mcp('/mcp/voice/lol/live')
+    ->setServerInfo(
+        name: 'OP.GG MCP Server - Voice lol Live',
+        version: '1.0.0',
+    )
+    ->dynamicTools(LolPhaseToolResolver::class);
+```
+
+Example requests:
+
+```text
+/mcp/voice/lol/live?phase=lobby
+/mcp/voice/lol/live?phase=inprogress
+```
+
+The same filtered tool set is applied consistently to:
+- `tools/list`
+- `tools/call`
+- `tools/execute`
+- `POST /tools/{tool_name}` when `->enabledApi()` is enabled
+
+If the same endpoint also uses `POST /tools/{tool_name}`, expose a public `consumedQueryParameters(): array`
+hook on the resolver for query keys that should be used only for filtering and not forwarded as tool arguments.
+
 ## Lumen Setup
 
 ```php
@@ -256,7 +325,7 @@ Route::mcp('/mcp')
 
 ## MCP Tools -> OpenAPI Export
 
-Export all registered `ToolInterface` classes (via `Route::mcp(...)->tools([...])`) to an OpenAPI JSON document using each tool's `inputSchema()`.
+Export all registered `ToolInterface` classes (via `Route::mcp(...)->tools([...])` or `->dynamicTools(...)`) to an OpenAPI JSON document using each tool's `inputSchema()`.
 Only endpoints configured with `->enabledApi()` are included in this export and exposed through `POST /tools/{tool_name}`.
 Operations are grouped by endpoint `name` using OpenAPI `tags`.
 If multiple endpoints register the same tool name, the operation keeps first-registration behavior and merges all matching endpoint names into `tags`.

--- a/src/Console/Commands/ExportToolsOpenApiCommand.php
+++ b/src/Console/Commands/ExportToolsOpenApiCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use OPGG\LaravelMcpServer\JsonSchema\Types\Type;
 use OPGG\LaravelMcpServer\Routing\McpEndpointDefinition;
 use OPGG\LaravelMcpServer\Routing\McpEndpointRegistry;
+use OPGG\LaravelMcpServer\Services\ToolService\EndpointToolCatalog;
 use OPGG\LaravelMcpServer\Services\ToolService\ToolInterface;
 use OPGG\LaravelMcpServer\Utils\JsonSchemaNormalizer;
 use stdClass;
@@ -46,7 +47,7 @@ class ExportToolsOpenApiCommand extends Command
         if ($toolEntries === []) {
             $this->warn(
                 'No MCP tools are available for API export. '.
-                'Use Route::mcp(...)->enabledApi()->tools([...]) to register endpoint tools.'
+                'Use Route::mcp(...)->enabledApi()->tools([...]) or ->dynamicTools(...) to register endpoint tools.'
             );
 
             return 0;
@@ -226,6 +227,8 @@ class ExportToolsOpenApiCommand extends Command
     {
         /** @var McpEndpointRegistry $registry */
         $registry = app(McpEndpointRegistry::class);
+        /** @var EndpointToolCatalog $toolCatalog */
+        $toolCatalog = app(EndpointToolCatalog::class);
 
         $endpointFilter = $this->option('endpoint');
         $needle = is_string($endpointFilter) && trim($endpointFilter) !== '' ? trim($endpointFilter) : null;
@@ -248,7 +251,7 @@ class ExportToolsOpenApiCommand extends Command
             $matchedApiEnabledEndpoint = true;
             $tag = $this->resolveEndpointTag($definition);
 
-            foreach ($definition->tools as $toolClass) {
+            foreach ($toolCatalog->declaredToolClasses($definition) as $toolClass) {
                 $tool = $this->resolveToolInstance($toolClass);
                 if ($tool === null) {
                     continue;

--- a/src/Console/Commands/MakeMcpNotificationCommand.php
+++ b/src/Console/Commands/MakeMcpNotificationCommand.php
@@ -25,7 +25,7 @@ class MakeMcpNotificationCommand extends Command
     /**
      * The filesystem instance.
      *
-     * @var \Illuminate\Filesystem\Filesystem
+     * @var Filesystem
      */
     protected $files;
 

--- a/src/Console/Commands/MakeMcpResourceCommand.php
+++ b/src/Console/Commands/MakeMcpResourceCommand.php
@@ -25,7 +25,7 @@ class MakeMcpResourceCommand extends Command
     /**
      * The filesystem instance.
      *
-     * @var \Illuminate\Filesystem\Filesystem
+     * @var Filesystem
      */
     protected $files;
 

--- a/src/Console/Commands/MakeMcpToolCommand.php
+++ b/src/Console/Commands/MakeMcpToolCommand.php
@@ -25,7 +25,7 @@ class MakeMcpToolCommand extends Command
     /**
      * The filesystem instance.
      *
-     * @var \Illuminate\Filesystem\Filesystem
+     * @var Filesystem
      */
     protected $files;
 

--- a/src/Console/Commands/MakeSwaggerMcpToolCommand.php
+++ b/src/Console/Commands/MakeSwaggerMcpToolCommand.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use OPGG\LaravelMcpServer\Services\SwaggerParser\SwaggerParser;
 use OPGG\LaravelMcpServer\Services\SwaggerParser\SwaggerToMcpConverter;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 class MakeSwaggerMcpToolCommand extends Command
 {
@@ -768,12 +770,12 @@ class MakeSwaggerMcpToolCommand extends Command
                 $makeTool->setLaravel($this->getLaravel());
                 $makeTool->setDynamicParams($toolParams);
 
-                $input = new \Symfony\Component\Console\Input\ArrayInput([
+                $input = new ArrayInput([
                     'name' => $className,
                     '--programmatic' => true,
                 ]);
 
-                $output = new \Symfony\Component\Console\Output\NullOutput;
+                $output = new NullOutput;
 
                 try {
                     $makeTool->run($input, $output);
@@ -810,12 +812,12 @@ class MakeSwaggerMcpToolCommand extends Command
                 $makeResource->setLaravel($this->getLaravel());
                 $makeResource->setDynamicParams($resourceParams);
 
-                $input = new \Symfony\Component\Console\Input\ArrayInput([
+                $input = new ArrayInput([
                     'name' => $className,
                     '--programmatic' => true,
                 ]);
 
-                $output = new \Symfony\Component\Console\Output\NullOutput;
+                $output = new NullOutput;
 
                 try {
                     $makeResource->run($input, $output);

--- a/src/Console/Commands/TestMcpToolCommand.php
+++ b/src/Console/Commands/TestMcpToolCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 use OPGG\LaravelMcpServer\Routing\McpEndpointDefinition;
 use OPGG\LaravelMcpServer\Routing\McpEndpointRegistry;
+use OPGG\LaravelMcpServer\Services\ToolService\EndpointToolCatalog;
 use OPGG\LaravelMcpServer\Services\ToolService\ToolInterface;
 use OPGG\LaravelMcpServer\Utils\JsonSchemaNormalizer;
 
@@ -307,7 +308,7 @@ class TestMcpToolCommand extends Command
         $configuredTools = $this->getRegisteredToolClasses();
 
         if (empty($configuredTools)) {
-            $this->warn('No MCP tools are registered. Use Route::mcp(...)->tools([...]) to register endpoint tools.');
+            $this->warn('No MCP tools are registered. Use Route::mcp(...)->tools([...]) or ->dynamicTools(...) to register endpoint tools.');
 
             return 0;
         }
@@ -349,7 +350,7 @@ class TestMcpToolCommand extends Command
         $configuredTools = $this->getRegisteredToolClasses();
 
         if (empty($configuredTools)) {
-            $this->warn('No MCP tools are registered. Use Route::mcp(...)->tools([...]) to register endpoint tools.');
+            $this->warn('No MCP tools are registered. Use Route::mcp(...)->tools([...]) or ->dynamicTools(...) to register endpoint tools.');
 
             return null;
         }
@@ -393,17 +394,26 @@ class TestMcpToolCommand extends Command
     {
         /** @var McpEndpointRegistry $registry */
         $registry = app(McpEndpointRegistry::class);
+        /** @var EndpointToolCatalog $toolCatalog */
+        $toolCatalog = app(EndpointToolCatalog::class);
 
         $endpointFilter = $this->option('endpoint');
         if (! is_string($endpointFilter) || trim($endpointFilter) === '') {
-            return $registry->allToolClasses();
+            $toolClasses = [];
+            foreach ($registry->all() as $definition) {
+                foreach ($toolCatalog->declaredToolClasses($definition) as $toolClass) {
+                    $toolClasses[$toolClass] = $toolClass;
+                }
+            }
+
+            return array_values($toolClasses);
         }
 
         $needle = trim($endpointFilter);
         $matchedTools = [];
         foreach ($registry->all() as $definition) {
             if ($this->matchesEndpoint($definition, $needle)) {
-                foreach ($definition->tools as $toolClass) {
+                foreach ($toolCatalog->declaredToolClasses($definition) as $toolClass) {
                     $matchedTools[$toolClass] = $toolClass;
                 }
             }

--- a/src/Contracts/JsonSchema/JsonSchema.php
+++ b/src/Contracts/JsonSchema/JsonSchema.php
@@ -3,49 +3,56 @@
 namespace OPGG\LaravelMcpServer\Contracts\JsonSchema;
 
 use Closure;
+use OPGG\LaravelMcpServer\JsonSchema\Types\ArrayType;
+use OPGG\LaravelMcpServer\JsonSchema\Types\BooleanType;
+use OPGG\LaravelMcpServer\JsonSchema\Types\IntegerType;
+use OPGG\LaravelMcpServer\JsonSchema\Types\NumberType;
+use OPGG\LaravelMcpServer\JsonSchema\Types\ObjectType;
+use OPGG\LaravelMcpServer\JsonSchema\Types\StringType;
+use OPGG\LaravelMcpServer\JsonSchema\Types\Type;
 
 interface JsonSchema
 {
     /**
      * Create a new object schema instance.
      *
-     * @param  (Closure(JsonSchema): array<string, \OPGG\LaravelMcpServer\JsonSchema\Types\Type>)|array<string, \OPGG\LaravelMcpServer\JsonSchema\Types\Type>  $properties
-     * @return \OPGG\LaravelMcpServer\JsonSchema\Types\ObjectType
+     * @param  (Closure(JsonSchema): array<string, Type>)|array<string, Type>  $properties
+     * @return ObjectType
      */
     public function object(Closure|array $properties = []);
 
     /**
      * Create a new array property instance.
      *
-     * @return \OPGG\LaravelMcpServer\JsonSchema\Types\ArrayType
+     * @return ArrayType
      */
     public function array();
 
     /**
      * Create a new string property instance.
      *
-     * @return \OPGG\LaravelMcpServer\JsonSchema\Types\StringType
+     * @return StringType
      */
     public function string();
 
     /**
      * Create a new integer property instance.
      *
-     * @return \OPGG\LaravelMcpServer\JsonSchema\Types\IntegerType
+     * @return IntegerType
      */
     public function integer();
 
     /**
      * Create a new number property instance.
      *
-     * @return \OPGG\LaravelMcpServer\JsonSchema\Types\NumberType
+     * @return NumberType
      */
     public function number();
 
     /**
      * Create a new boolean property instance.
      *
-     * @return \OPGG\LaravelMcpServer\JsonSchema\Types\BooleanType
+     * @return BooleanType
      */
     public function boolean();
 }

--- a/src/Data/Resources/JsonRpc/JsonRpcErrorResource.php
+++ b/src/Data/Resources/JsonRpc/JsonRpcErrorResource.php
@@ -26,7 +26,7 @@ class JsonRpcErrorResource
     /**
      * Constructor for JsonRpcErrorResource.
      *
-     * @param  \OPGG\LaravelMcpServer\Exceptions\JsonRpcErrorException  $exception  The exception representing the JSON-RPC error.
+     * @param  JsonRpcErrorException  $exception  The exception representing the JSON-RPC error.
      * @param  string|int|null  $id  The ID of the original request, if available.
      */
     public function __construct(JsonRpcErrorException $exception, string|int|null $id = null)

--- a/src/Data/ToolResolutionContext.php
+++ b/src/Data/ToolResolutionContext.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace OPGG\LaravelMcpServer\Data;
+
+final class ToolResolutionContext
+{
+    /**
+     * @param  array<int|string, mixed>  $queryParameters
+     * @param  array<string, mixed>|null  $requestMessage
+     */
+    public function __construct(
+        public readonly array $queryParameters = [],
+        public readonly ?array $requestMessage = null,
+    ) {}
+}

--- a/src/Http/Controllers/StreamableHttpController.php
+++ b/src/Http/Controllers/StreamableHttpController.php
@@ -8,12 +8,14 @@ use Illuminate\Support\Str;
 use JsonException;
 use OPGG\LaravelMcpServer\Data\Resources\JsonRpc\JsonRpcErrorResource;
 use OPGG\LaravelMcpServer\Data\Resources\JsonRpc\JsonRpcResultResource;
+use OPGG\LaravelMcpServer\Data\ToolResolutionContext;
 use OPGG\LaravelMcpServer\Exceptions\Enums\JsonRpcErrorCode;
 use OPGG\LaravelMcpServer\Exceptions\JsonRpcErrorException;
 use OPGG\LaravelMcpServer\Routing\McpEndpointDefinition;
 use OPGG\LaravelMcpServer\Routing\McpEndpointRegistry;
 use OPGG\LaravelMcpServer\Routing\McpRouteRegistrar;
 use OPGG\LaravelMcpServer\Server\McpServerFactory;
+use OPGG\LaravelMcpServer\Utils\RequestQueryParameterUtil;
 
 class StreamableHttpController
 {
@@ -54,7 +56,14 @@ class StreamableHttpController
             );
         }
 
-        $server = $this->serverFactory->make($endpoint, $messageJson);
+        $server = $this->serverFactory->make(
+            endpoint: $endpoint,
+            requestMessage: $messageJson,
+            toolResolutionContext: new ToolResolutionContext(
+                queryParameters: RequestQueryParameterUtil::all($request),
+                requestMessage: is_array($messageJson) ? $messageJson : null,
+            ),
+        );
 
         $mcpSessionId = $this->resolveSessionId($request);
 

--- a/src/Http/Controllers/ToolApiController.php
+++ b/src/Http/Controllers/ToolApiController.php
@@ -5,10 +5,15 @@ namespace OPGG\LaravelMcpServer\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use JsonException;
+use OPGG\LaravelMcpServer\Data\ToolResolutionContext;
 use OPGG\LaravelMcpServer\Exceptions\Enums\JsonRpcErrorCode;
 use OPGG\LaravelMcpServer\Routing\McpEndpointDefinition;
 use OPGG\LaravelMcpServer\Routing\McpEndpointRegistry;
 use OPGG\LaravelMcpServer\Server\McpServerFactory;
+use OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface;
+use OPGG\LaravelMcpServer\Services\ToolService\EndpointToolCatalog;
+use OPGG\LaravelMcpServer\Utils\RequestQueryParameterUtil;
+use Symfony\Component\HttpFoundation\Exception\JsonException as HttpFoundationJsonException;
 use Symfony\Component\HttpFoundation\Response;
 
 class ToolApiController
@@ -16,6 +21,7 @@ class ToolApiController
     public function __construct(
         private readonly McpEndpointRegistry $endpointRegistry,
         private readonly McpServerFactory $serverFactory,
+        private readonly EndpointToolCatalog $endpointToolCatalog,
     ) {}
 
     public function handle(Request $request, string $tool_name)
@@ -27,25 +33,56 @@ class ToolApiController
             ], Response::HTTP_BAD_REQUEST);
         }
 
+        $queryParameters = RequestQueryParameterUtil::all($request);
         try {
-            $arguments = $this->parseArguments($request);
-        } catch (JsonException) {
-            return response()->json([
-                'message' => 'Parse error',
-                'code' => JsonRpcErrorCode::PARSE_ERROR->value,
-            ], Response::HTTP_BAD_REQUEST);
+            $payloadArguments = $this->parsePayloadArguments($request);
+        } catch (JsonException|HttpFoundationJsonException) {
+            if (! $this->shouldIgnorePayloadException($toolName, $queryParameters)) {
+                return response()->json([
+                    'message' => 'Parse error',
+                    'code' => JsonRpcErrorCode::PARSE_ERROR->value,
+                ], Response::HTTP_BAD_REQUEST);
+            }
+
+            $payloadArguments = [];
         } catch (\InvalidArgumentException $exception) {
-            return response()->json([
-                'message' => $exception->getMessage(),
-                'code' => JsonRpcErrorCode::INVALID_REQUEST->value,
-            ], Response::HTTP_BAD_REQUEST);
+            if (! $this->shouldIgnorePayloadException($toolName, $queryParameters)) {
+                return response()->json([
+                    'message' => $exception->getMessage(),
+                    'code' => JsonRpcErrorCode::INVALID_REQUEST->value,
+                ], Response::HTTP_BAD_REQUEST);
+            }
+
+            $payloadArguments = [];
         }
 
         $sessionId = $this->sessionId($request);
 
         foreach ($this->enabledEndpoints() as $endpoint) {
+            $arguments = $this->mergeArguments(
+                payloadArguments: $payloadArguments,
+                queryParameters: $queryParameters,
+                endpoint: $endpoint,
+            );
             $message = $this->toolExecuteMessage($toolName, $arguments);
-            $server = $this->serverFactory->make($endpoint, $message);
+            $toolResolutionContext = new ToolResolutionContext(
+                queryParameters: $queryParameters,
+                requestMessage: $message,
+            );
+
+            if (! $this->endpointToolCatalog->declaresToolName($endpoint, $toolName)) {
+                continue;
+            }
+
+            if (! $this->endpointToolCatalog->exposesToolName($endpoint, $toolName, $toolResolutionContext)) {
+                return $this->toolNotFoundResponse($toolName);
+            }
+
+            $server = $this->serverFactory->make(
+                endpoint: $endpoint,
+                requestMessage: $message,
+                toolResolutionContext: $toolResolutionContext,
+            );
             $responseData = $server->requestMessage(clientId: $sessionId, message: $message)->toArray();
 
             $error = $responseData['error'] ?? null;
@@ -57,28 +94,20 @@ class ToolApiController
 
             $errorCode = $error['code'] ?? null;
             if ($errorCode === JsonRpcErrorCode::METHOD_NOT_FOUND->value) {
-                continue;
+                return response()->json($error, Response::HTTP_NOT_FOUND);
             }
 
             return response()->json($error, $this->errorHttpStatus($errorCode));
         }
 
-        return response()->json([
-            'message' => "Tool '{$toolName}' not found",
-            'code' => JsonRpcErrorCode::METHOD_NOT_FOUND->value,
-        ], Response::HTTP_NOT_FOUND);
+        return $this->toolNotFoundResponse($toolName);
     }
 
     /**
      * @return array<int|string, mixed>
      */
-    private function parseArguments(Request $request): array
+    private function parsePayloadArguments(Request $request): array
     {
-        $queryArguments = $this->parseQueryArguments($request);
-        if ($queryArguments !== []) {
-            return $queryArguments;
-        }
-
         $formArguments = $request->request->all();
         if ($formArguments !== []) {
             return $formArguments;
@@ -100,40 +129,81 @@ class ToolApiController
     /**
      * @return array<int|string, mixed>
      */
-    private function parseQueryArguments(Request $request): array
+    private function mergeArguments(array $payloadArguments, array $queryParameters, McpEndpointDefinition $endpoint): array
     {
-        $queryArguments = $request->query->all();
-
-        $queryString = $request->server('QUERY_STRING');
-        if (! is_string($queryString) || trim($queryString) === '') {
-            return $queryArguments;
+        $queryArguments = $queryParameters;
+        foreach ($this->consumedQueryParameters($endpoint) as $parameterName) {
+            unset($queryArguments[$parameterName]);
         }
 
-        $valuesByKey = [];
-        foreach (explode('&', $queryString) as $segment) {
-            if ($segment === '') {
+        if ($queryArguments === []) {
+            return $payloadArguments;
+        }
+
+        return array_replace($payloadArguments, $queryArguments);
+    }
+
+    /**
+     * Preserve legacy query-precedence behavior only when the selected endpoint
+     * still receives at least one real tool argument after removing filter-only keys.
+     *
+     * @param  array<int|string, mixed>  $queryParameters
+     */
+    private function shouldIgnorePayloadException(string $toolName, array $queryParameters): bool
+    {
+        if ($queryParameters === []) {
+            return false;
+        }
+
+        foreach ($this->enabledEndpoints() as $endpoint) {
+            if (! $this->endpointToolCatalog->declaresToolName($endpoint, $toolName)) {
                 continue;
             }
 
-            $parts = explode('=', $segment, 2);
-            $key = urldecode($parts[0]);
-            if ($key === '' || str_ends_with($key, '[]') || str_contains($key, '[')) {
+            return $this->mergeArguments([], $queryParameters, $endpoint) !== [];
+        }
+
+        return true;
+    }
+
+    /**
+     * Dynamic resolvers can expose public consumedQueryParameters() to reserve
+     * endpoint-level selectors such as "phase" for filtering only.
+     *
+     * @return array<int, string>
+     */
+    private function consumedQueryParameters(McpEndpointDefinition $endpoint): array
+    {
+        $resolverClass = $endpoint->dynamicToolsResolver;
+        if ($resolverClass === null || ! is_a($resolverClass, DynamicToolResolverInterface::class, true)) {
+            return [];
+        }
+
+        $resolver = app()->make($resolverClass);
+        if (! $resolver instanceof DynamicToolResolverInterface) {
+            return [];
+        }
+
+        $callable = [$resolver, 'consumedQueryParameters'];
+        if (! is_callable($callable)) {
+            return [];
+        }
+
+        $parameterNames = call_user_func($callable);
+        if (! is_array($parameterNames)) {
+            return [];
+        }
+
+        $normalizedParameterNames = [];
+        foreach ($parameterNames as $parameterName) {
+            if (! is_string($parameterName) || $parameterName === '') {
                 continue;
             }
 
-            $value = urldecode($parts[1] ?? '');
-            $valuesByKey[$key][] = $value;
+            $normalizedParameterNames[$parameterName] = $parameterName;
         }
 
-        foreach ($valuesByKey as $key => $values) {
-            if (count($values) <= 1) {
-                continue;
-            }
-
-            $queryArguments[$key] = $values;
-        }
-
-        return $queryArguments;
+        return array_values($normalizedParameterNames);
     }
 
     private function sessionId(Request $request): string
@@ -192,5 +262,13 @@ class ToolApiController
             JsonRpcErrorCode::INVALID_PARAMS->value => Response::HTTP_BAD_REQUEST,
             default => Response::HTTP_INTERNAL_SERVER_ERROR,
         };
+    }
+
+    private function toolNotFoundResponse(string $toolName)
+    {
+        return response()->json([
+            'message' => "Tool '{$toolName}' not found",
+            'code' => JsonRpcErrorCode::METHOD_NOT_FOUND->value,
+        ], Response::HTTP_NOT_FOUND);
     }
 }

--- a/src/JsonSchema/Serializer.php
+++ b/src/JsonSchema/Serializer.php
@@ -18,7 +18,7 @@ class Serializer
      *
      * @return array<string, mixed>
      *
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
     public static function serialize(Types\Type $type, ?int $compactEnumExampleCount = null): array
     {

--- a/src/JsonSchema/Types/Type.php
+++ b/src/JsonSchema/Types/Type.php
@@ -125,7 +125,7 @@ abstract class Type extends JsonSchema
      *
      * @param  class-string|array<int, mixed>  $values
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function enum(array|string $values): static
     {
@@ -145,7 +145,7 @@ abstract class Type extends JsonSchema
      * @param  class-string  $enumClass
      * @return array<int, int|string>
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     private function resolveBackedEnumValues(string $enumClass): array
     {

--- a/src/LaravelMcpServerServiceProvider.php
+++ b/src/LaravelMcpServerServiceProvider.php
@@ -15,6 +15,7 @@ use OPGG\LaravelMcpServer\Console\Commands\TestMcpToolCommand;
 use OPGG\LaravelMcpServer\Routing\McpEndpointRegistry;
 use OPGG\LaravelMcpServer\Routing\McpRouteRegistrar;
 use OPGG\LaravelMcpServer\Server\McpServerFactory;
+use OPGG\LaravelMcpServer\Services\ToolService\EndpointToolCatalog;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -49,6 +50,7 @@ class LaravelMcpServerServiceProvider extends PackageServiceProvider
         $this->app->singleton(LaravelMcpServer::class);
         $this->app->singleton(McpEndpointRegistry::class);
         $this->app->singleton(McpRouteRegistrar::class);
+        $this->app->singleton(EndpointToolCatalog::class);
         $this->app->singleton(McpServerFactory::class);
     }
 

--- a/src/Routing/McpEndpointDefinition.php
+++ b/src/Routing/McpEndpointDefinition.php
@@ -3,6 +3,8 @@
 namespace OPGG\LaravelMcpServer\Routing;
 
 use OPGG\LaravelMcpServer\Enums\ProtocolVersion;
+use OPGG\LaravelMcpServer\Server\Request\ToolsCallHandler;
+use OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface;
 
 final class McpEndpointDefinition
 {
@@ -20,8 +22,8 @@ final class McpEndpointDefinition
      * @param  array<int, class-string>  $resourceTemplates
      * @param  array<int, class-string>  $prompts
      * @param  array<int, array{src: string, mimeType?: string, sizes?: array<int, string>, theme?: 'light'|'dark'}>  $icons
-     * @param  class-string<\OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface>|null  $dynamicToolsResolver
-     * @param  class-string<\OPGG\LaravelMcpServer\Server\Request\ToolsCallHandler>|null  $toolsCallHandler
+     * @param  class-string<DynamicToolResolverInterface>|null  $dynamicToolsResolver
+     * @param  class-string<ToolsCallHandler>|null  $toolsCallHandler
      */
     public function __construct(
         public readonly string $id,
@@ -133,7 +135,7 @@ final class McpEndpointDefinition
     }
 
     /**
-     * @param  class-string<\OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface>|null  $resolverClass
+     * @param  class-string<DynamicToolResolverInterface>|null  $resolverClass
      */
     public function withDynamicToolsResolver(?string $resolverClass): self
     {
@@ -144,7 +146,7 @@ final class McpEndpointDefinition
     }
 
     /**
-     * @param  class-string<\OPGG\LaravelMcpServer\Server\Request\ToolsCallHandler>|null  $handlerClass
+     * @param  class-string<ToolsCallHandler>|null  $handlerClass
      */
     public function withToolsCallHandler(?string $handlerClass): self
     {
@@ -202,8 +204,8 @@ final class McpEndpointDefinition
      *   resources: array<int, class-string>,
      *   resourceTemplates: array<int, class-string>,
      *   prompts: array<int, class-string>,
-     *   dynamicToolsResolver: class-string<\OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface>|null,
-     *   toolsCallHandler: class-string<\OPGG\LaravelMcpServer\Server\Request\ToolsCallHandler>|null,
+     *   dynamicToolsResolver: class-string<DynamicToolResolverInterface>|null,
+     *   toolsCallHandler: class-string<ToolsCallHandler>|null,
      *   enabledApi: bool,
      *   toolListChanged: bool,
      *   resourcesSubscribe: bool,
@@ -286,8 +288,8 @@ final class McpEndpointDefinition
      *   resources?: array<int, class-string>,
      *   resourceTemplates?: array<int, class-string>,
      *   prompts?: array<int, class-string>,
-     *   dynamicToolsResolver?: class-string<\OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface>|null,
-     *   toolsCallHandler?: class-string<\OPGG\LaravelMcpServer\Server\Request\ToolsCallHandler>|null,
+     *   dynamicToolsResolver?: class-string<DynamicToolResolverInterface>|null,
+     *   toolsCallHandler?: class-string<ToolsCallHandler>|null,
      *   enabledApi?: bool,
      *   toolListChanged?: bool,
      *   resourcesSubscribe?: bool,
@@ -344,8 +346,8 @@ final class McpEndpointDefinition
      *   resources: array<int, class-string>,
      *   resourceTemplates: array<int, class-string>,
      *   prompts: array<int, class-string>,
-     *   dynamicToolsResolver: class-string<\OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface>|null,
-     *   toolsCallHandler: class-string<\OPGG\LaravelMcpServer\Server\Request\ToolsCallHandler>|null,
+     *   dynamicToolsResolver: class-string<DynamicToolResolverInterface>|null,
+     *   toolsCallHandler: class-string<ToolsCallHandler>|null,
      *   enabledApi: bool,
      *   toolListChanged: bool,
      *   resourcesSubscribe: bool,

--- a/src/Routing/McpEndpointDefinition.php
+++ b/src/Routing/McpEndpointDefinition.php
@@ -20,6 +20,7 @@ final class McpEndpointDefinition
      * @param  array<int, class-string>  $resourceTemplates
      * @param  array<int, class-string>  $prompts
      * @param  array<int, array{src: string, mimeType?: string, sizes?: array<int, string>, theme?: 'light'|'dark'}>  $icons
+     * @param  class-string<\OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface>|null  $dynamicToolsResolver
      * @param  class-string<\OPGG\LaravelMcpServer\Server\Request\ToolsCallHandler>|null  $toolsCallHandler
      */
     public function __construct(
@@ -37,6 +38,7 @@ final class McpEndpointDefinition
         public readonly array $resources = [],
         public readonly array $resourceTemplates = [],
         public readonly array $prompts = [],
+        public readonly ?string $dynamicToolsResolver = null,
         public readonly ?string $toolsCallHandler = null,
         public readonly bool $enabledApi = false,
         public readonly bool $toolListChanged = false,
@@ -100,7 +102,10 @@ final class McpEndpointDefinition
      */
     public function withTools(array $tools): self
     {
-        return $this->copy(['tools' => array_values($tools)]);
+        return $this->copy([
+            'tools' => array_values($tools),
+            'dynamicToolsResolver' => null,
+        ]);
     }
 
     /**
@@ -125,6 +130,17 @@ final class McpEndpointDefinition
     public function withPrompts(array $prompts): self
     {
         return $this->copy(['prompts' => array_values($prompts)]);
+    }
+
+    /**
+     * @param  class-string<\OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface>|null  $resolverClass
+     */
+    public function withDynamicToolsResolver(?string $resolverClass): self
+    {
+        return $this->copy([
+            'dynamicToolsResolver' => $resolverClass,
+            'tools' => [],
+        ]);
     }
 
     /**
@@ -186,6 +202,7 @@ final class McpEndpointDefinition
      *   resources: array<int, class-string>,
      *   resourceTemplates: array<int, class-string>,
      *   prompts: array<int, class-string>,
+     *   dynamicToolsResolver: class-string<\OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface>|null,
      *   toolsCallHandler: class-string<\OPGG\LaravelMcpServer\Server\Request\ToolsCallHandler>|null,
      *   enabledApi: bool,
      *   toolListChanged: bool,
@@ -228,6 +245,7 @@ final class McpEndpointDefinition
             resources: self::arrayOrDefault($state['resources'] ?? null),
             resourceTemplates: self::arrayOrDefault($state['resourceTemplates'] ?? null),
             prompts: self::arrayOrDefault($state['prompts'] ?? null),
+            dynamicToolsResolver: self::nullableString($state['dynamicToolsResolver'] ?? null),
             toolsCallHandler: self::nullableString($state['toolsCallHandler'] ?? null),
             enabledApi: self::boolOrDefault($state['enabledApi'] ?? null, false),
             toolListChanged: self::boolOrDefault($state['toolListChanged'] ?? null, false),
@@ -268,6 +286,7 @@ final class McpEndpointDefinition
      *   resources?: array<int, class-string>,
      *   resourceTemplates?: array<int, class-string>,
      *   prompts?: array<int, class-string>,
+     *   dynamicToolsResolver?: class-string<\OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface>|null,
      *   toolsCallHandler?: class-string<\OPGG\LaravelMcpServer\Server\Request\ToolsCallHandler>|null,
      *   enabledApi?: bool,
      *   toolListChanged?: bool,
@@ -297,6 +316,7 @@ final class McpEndpointDefinition
             resources: $state['resources'],
             resourceTemplates: $state['resourceTemplates'],
             prompts: $state['prompts'],
+            dynamicToolsResolver: $state['dynamicToolsResolver'],
             toolsCallHandler: $state['toolsCallHandler'],
             enabledApi: $state['enabledApi'],
             toolListChanged: $state['toolListChanged'],
@@ -324,6 +344,7 @@ final class McpEndpointDefinition
      *   resources: array<int, class-string>,
      *   resourceTemplates: array<int, class-string>,
      *   prompts: array<int, class-string>,
+     *   dynamicToolsResolver: class-string<\OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface>|null,
      *   toolsCallHandler: class-string<\OPGG\LaravelMcpServer\Server\Request\ToolsCallHandler>|null,
      *   enabledApi: bool,
      *   toolListChanged: bool,
@@ -351,6 +372,7 @@ final class McpEndpointDefinition
             'resources' => $this->resources,
             'resourceTemplates' => $this->resourceTemplates,
             'prompts' => $this->prompts,
+            'dynamicToolsResolver' => $this->dynamicToolsResolver,
             'toolsCallHandler' => $this->toolsCallHandler,
             'enabledApi' => $this->enabledApi,
             'toolListChanged' => $this->toolListChanged,

--- a/src/Routing/McpEndpointRegistry.php
+++ b/src/Routing/McpEndpointRegistry.php
@@ -3,6 +3,7 @@
 namespace OPGG\LaravelMcpServer\Routing;
 
 use Illuminate\Support\Str;
+use OPGG\LaravelMcpServer\Services\ToolService\EndpointToolCatalog;
 
 final class McpEndpointRegistry
 {
@@ -49,8 +50,11 @@ final class McpEndpointRegistry
     public function allToolClasses(): array
     {
         $tools = [];
+        /** @var EndpointToolCatalog $toolCatalog */
+        $toolCatalog = app(EndpointToolCatalog::class);
+
         foreach ($this->definitions as $definition) {
-            foreach ($definition->tools as $toolClass) {
+            foreach ($toolCatalog->declaredToolClasses($definition) as $toolClass) {
                 $tools[] = $toolClass;
             }
         }

--- a/src/Routing/McpRouteBuilder.php
+++ b/src/Routing/McpRouteBuilder.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 use OPGG\LaravelMcpServer\Enums\ProtocolVersion;
 use OPGG\LaravelMcpServer\Server\McpServerFactory;
 use OPGG\LaravelMcpServer\Server\Request\ToolsCallHandler;
+use OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface;
 
 final class McpRouteBuilder
 {
@@ -86,7 +87,15 @@ final class McpRouteBuilder
      */
     public function tools(array $tools): self
     {
-        $this->mutate(fn (McpEndpointDefinition $definition) => $definition->withTools($tools));
+        $this->mutate(function (McpEndpointDefinition $definition) use ($tools) {
+            if ($definition->dynamicToolsResolver !== null) {
+                throw new InvalidArgumentException(
+                    'Static tools cannot be configured after dynamic tools are declared.',
+                );
+            }
+
+            return $definition->withTools($tools);
+        });
 
         return $this;
     }
@@ -117,6 +126,32 @@ final class McpRouteBuilder
     public function prompts(array $prompts): self
     {
         $this->mutate(fn (McpEndpointDefinition $definition) => $definition->withPrompts($prompts));
+
+        return $this;
+    }
+
+    /**
+     * @param  class-string  $resolverClass
+     */
+    public function dynamicTools(string $resolverClass): self
+    {
+        if (! is_a(object_or_class: $resolverClass, class: DynamicToolResolverInterface::class, allow_string: true)) {
+            throw new InvalidArgumentException(sprintf(
+                'The dynamic tools resolver [%s] must implement %s.',
+                $resolverClass,
+                DynamicToolResolverInterface::class,
+            ));
+        }
+
+        $this->mutate(function (McpEndpointDefinition $definition) use ($resolverClass) {
+            if ($definition->tools !== []) {
+                throw new InvalidArgumentException(
+                    'Dynamic tools cannot be configured after static tools are declared.',
+                );
+            }
+
+            return $definition->withDynamicToolsResolver($resolverClass);
+        });
 
         return $this;
     }

--- a/src/Server/McpServerFactory.php
+++ b/src/Server/McpServerFactory.php
@@ -4,12 +4,14 @@ namespace OPGG\LaravelMcpServer\Server;
 
 use Illuminate\Container\Container;
 use InvalidArgumentException;
+use OPGG\LaravelMcpServer\Data\ToolResolutionContext;
 use OPGG\LaravelMcpServer\Protocol\MCPProtocol;
 use OPGG\LaravelMcpServer\Routing\McpEndpointDefinition;
 use OPGG\LaravelMcpServer\Server\Request\ToolsCallHandler;
 use OPGG\LaravelMcpServer\Server\Request\ToolsListHandler;
 use OPGG\LaravelMcpServer\Services\PromptService\PromptRepository;
 use OPGG\LaravelMcpServer\Services\ResourceService\ResourceRepository;
+use OPGG\LaravelMcpServer\Services\ToolService\EndpointToolCatalog;
 use OPGG\LaravelMcpServer\Services\ToolService\ToolInterface;
 use OPGG\LaravelMcpServer\Services\ToolService\ToolRepository;
 use OPGG\LaravelMcpServer\Transports\StreamableHttpTransport;
@@ -17,9 +19,9 @@ use OPGG\LaravelMcpServer\Transports\StreamableHttpTransport;
 final class McpServerFactory
 {
     /**
-     * Cached tool-name to class map by endpoint ID.
+     * Cached tool-name to class map by endpoint ID and filtered tool fingerprint.
      *
-     * @var array<string, array<string, class-string<ToolInterface>>>
+     * @var array<string, array<string, array<string, class-string<ToolInterface>>>>
      */
     private array $toolClassMapByEndpoint = [];
 
@@ -30,7 +32,10 @@ final class McpServerFactory
      */
     private array $toolNameByClass = [];
 
-    public function __construct(private readonly Container $container) {}
+    public function __construct(
+        private readonly Container $container,
+        private readonly EndpointToolCatalog $endpointToolCatalog,
+    ) {}
 
     /**
      * Clears all endpoint and class caches.
@@ -53,8 +58,11 @@ final class McpServerFactory
     /**
      * @param  array<string, mixed>|null  $requestMessage
      */
-    public function make(McpEndpointDefinition $endpoint, ?array $requestMessage = null): MCPServer
-    {
+    public function make(
+        McpEndpointDefinition $endpoint,
+        ?array $requestMessage = null,
+        ?ToolResolutionContext $toolResolutionContext = null
+    ): MCPServer {
         $requestedMethod = $this->requestedMethod($requestMessage);
 
         $capabilities = new ServerCapabilities;
@@ -85,6 +93,7 @@ final class McpServerFactory
         // Intentionally lazy-register repositories by method namespace to avoid
         // constructing unnecessary services for initialize/ping/notifications.
         if ($this->supportsToolsMethod($requestedMethod)) {
+            $toolClasses = $this->endpointToolCatalog->visibleToolClasses($endpoint, $toolResolutionContext);
             $toolRepository = new ToolRepository(
                 $this->container,
                 $endpoint->compactEnumExampleCount,
@@ -93,15 +102,15 @@ final class McpServerFactory
             if ($this->isToolCallMethod($requestedMethod)) {
                 $requestedToolName = $this->requestedToolName($requestMessage);
                 if ($requestedToolName !== null) {
-                    $toolClass = $this->resolveToolClassByName($endpoint, $requestedToolName);
+                    $toolClass = $this->resolveToolClassByName($endpoint, $toolClasses, $requestedToolName);
                     if ($toolClass !== null) {
                         $toolRepository->register($toolClass);
                     }
                 }
             } elseif ($this->isToolsListMethod($requestedMethod)) {
-                $toolRepository->registerSchemaMany($endpoint->tools);
+                $toolRepository->registerSchemaMany($toolClasses);
             } else {
-                $toolRepository->registerMany($endpoint->tools);
+                $toolRepository->registerMany($toolClasses);
             }
 
             if ($endpoint->toolsCallHandler === null) {
@@ -219,23 +228,31 @@ final class McpServerFactory
         return is_string($name) && $name !== '' ? $name : null;
     }
 
-    private function resolveToolClassByName(McpEndpointDefinition $endpoint, string $toolName): ?string
-    {
+    /**
+     * @param  array<int, class-string<ToolInterface>>  $toolClasses
+     */
+    private function resolveToolClassByName(
+        McpEndpointDefinition $endpoint,
+        array $toolClasses,
+        string $toolName
+    ): ?string {
         $endpointId = $endpoint->id;
-        if (! isset($this->toolClassMapByEndpoint[$endpointId])) {
-            $this->toolClassMapByEndpoint[$endpointId] = $this->buildToolClassMap($endpoint);
+        $fingerprint = $this->toolClassFingerprint($toolClasses);
+
+        if (! isset($this->toolClassMapByEndpoint[$endpointId][$fingerprint])) {
+            $this->toolClassMapByEndpoint[$endpointId][$fingerprint] = $this->buildToolClassMap($toolClasses);
         }
 
-        return $this->toolClassMapByEndpoint[$endpointId][$toolName] ?? null;
+        return $this->toolClassMapByEndpoint[$endpointId][$fingerprint][$toolName] ?? null;
     }
 
     /**
      * @return array<string, class-string<ToolInterface>>
      */
-    private function buildToolClassMap(McpEndpointDefinition $endpoint): array
+    private function buildToolClassMap(array $toolClasses): array
     {
         $map = [];
-        foreach ($endpoint->tools as $toolClass) {
+        foreach ($toolClasses as $toolClass) {
             $toolName = $this->toolNameByClass[$toolClass] ??= $this->resolveToolName($toolClass);
             $map[$toolName] = $toolClass;
         }
@@ -254,5 +271,13 @@ final class McpServerFactory
         }
 
         return $tool->name();
+    }
+
+    /**
+     * @param  array<int, class-string<ToolInterface>>  $toolClasses
+     */
+    private function toolClassFingerprint(array $toolClasses): string
+    {
+        return sha1(implode("\n", $toolClasses));
     }
 }

--- a/src/Services/ToolService/DynamicToolResolverInterface.php
+++ b/src/Services/ToolService/DynamicToolResolverInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OPGG\LaravelMcpServer\Services\ToolService;
+
+use OPGG\LaravelMcpServer\Data\ToolResolutionContext;
+use OPGG\LaravelMcpServer\Routing\McpEndpointDefinition;
+
+interface DynamicToolResolverInterface
+{
+    /**
+     * @return array<int, class-string<ToolInterface>>
+     */
+    public function declaredTools(McpEndpointDefinition $endpoint): array;
+
+    /**
+     * @return array<int, class-string<ToolInterface>>
+     */
+    public function resolve(McpEndpointDefinition $endpoint, ToolResolutionContext $context): array;
+}

--- a/src/Services/ToolService/EndpointToolCatalog.php
+++ b/src/Services/ToolService/EndpointToolCatalog.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace OPGG\LaravelMcpServer\Services\ToolService;
+
+use Illuminate\Container\Container;
+use InvalidArgumentException;
+use OPGG\LaravelMcpServer\Data\ToolResolutionContext;
+use OPGG\LaravelMcpServer\Routing\McpEndpointDefinition;
+
+final class EndpointToolCatalog
+{
+    /**
+     * @var array<class-string<ToolInterface>, string>
+     */
+    private array $toolNameByClass = [];
+
+    public function __construct(private readonly Container $container) {}
+
+    /**
+     * @return array<int, class-string<ToolInterface>>
+     */
+    public function declaredToolClasses(McpEndpointDefinition $endpoint): array
+    {
+        $this->assertConfigurationIsNotMixed($endpoint);
+
+        if ($endpoint->dynamicToolsResolver === null) {
+            return array_values(array_unique($endpoint->tools));
+        }
+
+        return $this->normalizeToolClasses(
+            $this->resolver($endpoint->dynamicToolsResolver)->declaredTools($endpoint),
+            'declared tools'
+        );
+    }
+
+    /**
+     * @return array<int, class-string<ToolInterface>>
+     */
+    public function visibleToolClasses(McpEndpointDefinition $endpoint, ?ToolResolutionContext $context = null): array
+    {
+        $declaredToolClasses = $this->declaredToolClasses($endpoint);
+        if ($endpoint->dynamicToolsResolver === null) {
+            return $declaredToolClasses;
+        }
+
+        $resolvedToolClasses = $this->normalizeToolClasses(
+            $this->resolver($endpoint->dynamicToolsResolver)->resolve(
+                $endpoint,
+                $context ?? new ToolResolutionContext,
+            ),
+            'resolved tools'
+        );
+
+        $declaredToolLookup = [];
+        foreach ($declaredToolClasses as $toolClass) {
+            $declaredToolLookup[$toolClass] = true;
+        }
+
+        $allowedToolClasses = [];
+        foreach ($resolvedToolClasses as $toolClass) {
+            if (! isset($declaredToolLookup[$toolClass])) {
+                throw new InvalidArgumentException(sprintf(
+                    'The dynamic tools resolver [%s] returned undeclared tool [%s].',
+                    $endpoint->dynamicToolsResolver,
+                    $toolClass,
+                ));
+            }
+
+            $allowedToolClasses[$toolClass] = true;
+        }
+
+        $visibleToolClasses = [];
+        foreach ($declaredToolClasses as $toolClass) {
+            if (isset($allowedToolClasses[$toolClass])) {
+                $visibleToolClasses[] = $toolClass;
+            }
+        }
+
+        return $visibleToolClasses;
+    }
+
+    public function declaresToolName(McpEndpointDefinition $endpoint, string $toolName): bool
+    {
+        return $this->containsToolName(
+            toolClasses: $this->declaredToolClasses($endpoint),
+            toolName: $toolName,
+        );
+    }
+
+    public function exposesToolName(
+        McpEndpointDefinition $endpoint,
+        string $toolName,
+        ?ToolResolutionContext $context = null,
+    ): bool {
+        return $this->containsToolName(
+            toolClasses: $this->visibleToolClasses($endpoint, $context),
+            toolName: $toolName,
+        );
+    }
+
+    private function assertConfigurationIsNotMixed(McpEndpointDefinition $endpoint): void
+    {
+        if ($endpoint->tools !== [] && $endpoint->dynamicToolsResolver !== null) {
+            throw new InvalidArgumentException(sprintf(
+                'MCP endpoint [%s] cannot declare both static tools and a dynamic tools resolver.',
+                $endpoint->path,
+            ));
+        }
+    }
+
+    private function resolver(string $resolverClass): DynamicToolResolverInterface
+    {
+        if (! is_a(object_or_class: $resolverClass, class: DynamicToolResolverInterface::class, allow_string: true)) {
+            throw new InvalidArgumentException(sprintf(
+                'The dynamic tools resolver [%s] must implement %s.',
+                $resolverClass,
+                DynamicToolResolverInterface::class,
+            ));
+        }
+
+        $resolver = $this->container->make($resolverClass);
+        if (! $resolver instanceof DynamicToolResolverInterface) {
+            throw new InvalidArgumentException(sprintf(
+                'The resolved dynamic tools resolver [%s] must implement %s.',
+                $resolverClass,
+                DynamicToolResolverInterface::class,
+            ));
+        }
+
+        return $resolver;
+    }
+
+    /**
+     * @param  array<int, mixed>  $toolClasses
+     * @return array<int, class-string<ToolInterface>>
+     */
+    private function normalizeToolClasses(array $toolClasses, string $source): array
+    {
+        $normalizedToolClasses = [];
+
+        foreach ($toolClasses as $toolClass) {
+            if (! is_string($toolClass) || $toolClass === '') {
+                throw new InvalidArgumentException(sprintf(
+                    'The dynamic tools resolver returned an invalid %s entry.',
+                    $source,
+                ));
+            }
+
+            $normalizedToolClasses[$toolClass] = $toolClass;
+        }
+
+        return array_values($normalizedToolClasses);
+    }
+
+    /**
+     * @param  array<int, class-string<ToolInterface>>  $toolClasses
+     */
+    private function containsToolName(array $toolClasses, string $toolName): bool
+    {
+        foreach ($toolClasses as $toolClass) {
+            if ($this->resolveToolName($toolClass) === $toolName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  class-string<ToolInterface>  $toolClass
+     */
+    private function resolveToolName(string $toolClass): string
+    {
+        $tool = $this->container->make($toolClass);
+        if (! $tool instanceof ToolInterface) {
+            throw new InvalidArgumentException('Tool must implement the '.ToolInterface::class);
+        }
+
+        return $this->toolNameByClass[$toolClass] ??= $tool->name();
+    }
+}

--- a/src/Utils/RequestQueryParameterUtil.php
+++ b/src/Utils/RequestQueryParameterUtil.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace OPGG\LaravelMcpServer\Utils;
+
+use Illuminate\Http\Request;
+
+final class RequestQueryParameterUtil
+{
+    /**
+     * @return array<int|string, mixed>
+     */
+    public static function all(Request $request): array
+    {
+        $queryParameters = $request->query->all();
+
+        $queryString = $request->server('QUERY_STRING');
+        if (! is_string($queryString) || trim($queryString) === '') {
+            return $queryParameters;
+        }
+
+        $valuesByKey = [];
+        foreach (explode('&', $queryString) as $segment) {
+            if ($segment === '') {
+                continue;
+            }
+
+            $parts = explode('=', $segment, 2);
+            $key = urldecode($parts[0]);
+            if ($key === '' || str_ends_with($key, '[]') || str_contains($key, '[')) {
+                continue;
+            }
+
+            $value = urldecode($parts[1] ?? '');
+            $valuesByKey[$key][] = $value;
+        }
+
+        foreach ($valuesByKey as $key => $values) {
+            if (count($values) <= 1) {
+                continue;
+            }
+
+            $queryParameters[$key] = $values;
+        }
+
+        return $queryParameters;
+    }
+}

--- a/tests/Console/Commands/ExportToolsOpenApiCommandTest.php
+++ b/tests/Console/Commands/ExportToolsOpenApiCommandTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 use OPGG\LaravelMcpServer\Services\ToolService\Examples\HelloWorldTool;
+use OPGG\LaravelMcpServer\Tests\Fixtures\Resolvers\PhaseToolResolver;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\CompactEnumTool;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\DesiredOutputFieldsTool;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\EnumOnlyTool;
@@ -68,6 +69,21 @@ test('mcp:export-openapi generates openapi json from registered tools', function
         ->toBe(['csv', 'markdown'])
         ->and($json['components']['schemas']['TabularChampionsInput']['properties']['format']['enum'])
         ->toBe(['csv', 'markdown']);
+});
+
+test('mcp:export-openapi generates openapi json from declared dynamic tools', function () {
+    Route::mcp('/dynamic-mcp')->enabledApi()->dynamicTools(PhaseToolResolver::class);
+
+    $this->artisan('mcp:export-openapi', [
+        '--output' => exportCommandOutputPath(),
+    ])
+        ->expectsOutputToContain('Generated OpenAPI spec for 2 tool(s)')
+        ->assertExitCode(0);
+
+    $json = json_decode(File::get(exportCommandOutputPath()), true);
+
+    expect($json['paths'])->toHaveKey('/tools/legacy-array-tool')
+        ->and($json['paths'])->toHaveKey('/tools/structured-only-tool');
 });
 
 test('mcp:export-openapi can filter tools by endpoint id', function () {

--- a/tests/Console/Commands/MakeMcpResourceCommandTest.php
+++ b/tests/Console/Commands/MakeMcpResourceCommandTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
+use OPGG\LaravelMcpServer\Console\Commands\MakeMcpResourceCommand;
 
 beforeEach(function () {
     File::deleteDirectory(app_path('MCP/Resources'));
@@ -21,8 +23,8 @@ test('make:mcp-resource generates a resource class', function () {
 });
 
 test('getPath returns correct path without tag directory', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpResourceCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeMcpResourceCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'getPath');
     $method->setAccessible(true);
@@ -34,8 +36,8 @@ test('getPath returns correct path without tag directory', function () {
 });
 
 test('getPath returns correct path with tag directory', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpResourceCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeMcpResourceCommand($filesystem);
 
     $property = new ReflectionProperty($command, 'dynamicParams');
     $property->setAccessible(true);
@@ -51,8 +53,8 @@ test('getPath returns correct path with tag directory', function () {
 });
 
 test('replaceStubPlaceholders generates correct namespace without tag directory', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpResourceCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeMcpResourceCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'replaceStubPlaceholders');
     $method->setAccessible(true);
@@ -65,8 +67,8 @@ test('replaceStubPlaceholders generates correct namespace without tag directory'
 });
 
 test('replaceStubPlaceholders generates correct namespace with tag directory', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpResourceCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeMcpResourceCommand($filesystem);
 
     $property = new ReflectionProperty($command, 'dynamicParams');
     $property->setAccessible(true);
@@ -83,8 +85,8 @@ test('replaceStubPlaceholders generates correct namespace with tag directory', f
 });
 
 test('makeDirectory creates nested directories for resources', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpResourceCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeMcpResourceCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'makeDirectory');
     $method->setAccessible(true);

--- a/tests/Console/Commands/MakeMcpToolCommandTest.php
+++ b/tests/Console/Commands/MakeMcpToolCommandTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
+use OPGG\LaravelMcpServer\Console\Commands\MakeMcpToolCommand;
 
 beforeEach(function () {
     File::deleteDirectory(app_path('MCP/Tools'));
@@ -23,8 +25,8 @@ test('make:mcp-tool generates tool in root directory by default', function () {
 });
 
 test('getPath returns correct path without tag directory', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeMcpToolCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'getPath');
     $method->setAccessible(true);
@@ -36,8 +38,8 @@ test('getPath returns correct path without tag directory', function () {
 });
 
 test('getPath returns correct path with tag directory', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeMcpToolCommand($filesystem);
 
     $property = new ReflectionProperty($command, 'dynamicParams');
     $property->setAccessible(true);
@@ -53,8 +55,8 @@ test('getPath returns correct path with tag directory', function () {
 });
 
 test('replaceStubPlaceholders generates correct namespace without tag directory', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeMcpToolCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'replaceStubPlaceholders');
     $method->setAccessible(true);
@@ -68,8 +70,8 @@ test('replaceStubPlaceholders generates correct namespace without tag directory'
 });
 
 test('replaceStubPlaceholders generates correct namespace with tag directory', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeMcpToolCommand($filesystem);
 
     $property = new ReflectionProperty($command, 'dynamicParams');
     $property->setAccessible(true);
@@ -87,8 +89,8 @@ test('replaceStubPlaceholders generates correct namespace with tag directory', f
 });
 
 test('makeDirectory creates nested directories', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeMcpToolCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'makeDirectory');
     $method->setAccessible(true);
@@ -110,8 +112,8 @@ test('programmatic mode works without config files', function () {
 });
 
 test('handles directory creation permissions gracefully', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeMcpToolCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'makeDirectory');
     $method->setAccessible(true);

--- a/tests/Console/Commands/MakeSwaggerMcpToolCommandTest.php
+++ b/tests/Console/Commands/MakeSwaggerMcpToolCommandTest.php
@@ -1,6 +1,10 @@
 <?php
 
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
+use OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
+use OPGG\LaravelMcpServer\Services\SwaggerParser\SwaggerParser;
+use OPGG\LaravelMcpServer\Services\SwaggerParser\SwaggerToMcpConverter;
 
 beforeEach(function () {
     // Clean up directories before each test
@@ -16,10 +20,10 @@ afterEach(function () {
 
 // Test tag-based directory creation
 test('createDirectory returns tag-based directory by default', function () {
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
+    $command = new MakeSwaggerMcpToolCommand;
 
     // Mock the command and set the groupingMethod property
-    $command = \Mockery::mock($command)->makePartial();
+    $command = Mockery::mock($command)->makePartial();
 
     // Use reflection to set the groupingMethod property
     $property = new ReflectionProperty($command, 'groupingMethod');
@@ -36,10 +40,10 @@ test('createDirectory returns tag-based directory by default', function () {
 });
 
 test('createDirectory returns path-based directory', function () {
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
+    $command = new MakeSwaggerMcpToolCommand;
 
     // Mock the command and set the groupingMethod property
-    $command = \Mockery::mock($command)->makePartial();
+    $command = Mockery::mock($command)->makePartial();
 
     // Use reflection to set the groupingMethod property
     $property = new ReflectionProperty($command, 'groupingMethod');
@@ -56,10 +60,10 @@ test('createDirectory returns path-based directory', function () {
 });
 
 test('createDirectory returns empty string for none grouping', function () {
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
+    $command = new MakeSwaggerMcpToolCommand;
 
     // Mock the command and set the groupingMethod property
-    $command = \Mockery::mock($command)->makePartial();
+    $command = Mockery::mock($command)->makePartial();
 
     // Use reflection to set the groupingMethod property
     $property = new ReflectionProperty($command, 'groupingMethod');
@@ -76,8 +80,8 @@ test('createDirectory returns empty string for none grouping', function () {
 });
 
 test('createTagDirectory returns StudlyCase for single tag', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeSwaggerMcpToolCommand($filesystem);
 
     // Use reflection to access protected method
     $method = new ReflectionMethod($command, 'createTagDirectory');
@@ -90,8 +94,8 @@ test('createTagDirectory returns StudlyCase for single tag', function () {
 });
 
 test('createTagDirectory returns General for empty tags', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeSwaggerMcpToolCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'createTagDirectory');
     $method->setAccessible(true);
@@ -103,8 +107,8 @@ test('createTagDirectory returns General for empty tags', function () {
 });
 
 test('createTagDirectory returns General for missing tags key', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeSwaggerMcpToolCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'createTagDirectory');
     $method->setAccessible(true);
@@ -116,8 +120,8 @@ test('createTagDirectory returns General for missing tags key', function () {
 });
 
 test('createTagDirectory uses first tag when multiple tags exist', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeSwaggerMcpToolCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'createTagDirectory');
     $method->setAccessible(true);
@@ -129,8 +133,8 @@ test('createTagDirectory uses first tag when multiple tags exist', function () {
 });
 
 test('createTagDirectory handles special characters in tags', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeSwaggerMcpToolCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'createTagDirectory');
     $method->setAccessible(true);
@@ -142,8 +146,8 @@ test('createTagDirectory handles special characters in tags', function () {
 });
 
 test('createTagDirectory handles snake_case tags', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeSwaggerMcpToolCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'createTagDirectory');
     $method->setAccessible(true);
@@ -155,8 +159,8 @@ test('createTagDirectory handles snake_case tags', function () {
 });
 
 test('createTagDirectory handles numbers in tags', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeSwaggerMcpToolCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'createTagDirectory');
     $method->setAccessible(true);
@@ -169,7 +173,7 @@ test('createTagDirectory handles numbers in tags', function () {
 
 // Test path-based directory creation
 test('createPathDirectory returns StudlyCase for path segments', function () {
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
+    $command = new MakeSwaggerMcpToolCommand;
 
     $method = new ReflectionMethod($command, 'createPathDirectory');
     $method->setAccessible(true);
@@ -181,7 +185,7 @@ test('createPathDirectory returns StudlyCase for path segments', function () {
 });
 
 test('createPathDirectory returns Root for empty path', function () {
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
+    $command = new MakeSwaggerMcpToolCommand;
 
     $method = new ReflectionMethod($command, 'createPathDirectory');
     $method->setAccessible(true);
@@ -193,7 +197,7 @@ test('createPathDirectory returns Root for empty path', function () {
 });
 
 test('createPathDirectory handles snake_case path segments', function () {
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
+    $command = new MakeSwaggerMcpToolCommand;
 
     $method = new ReflectionMethod($command, 'createPathDirectory');
     $method->setAccessible(true);
@@ -205,7 +209,7 @@ test('createPathDirectory handles snake_case path segments', function () {
 });
 
 test('createPathDirectory handles kebab-case path segments', function () {
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
+    $command = new MakeSwaggerMcpToolCommand;
 
     $method = new ReflectionMethod($command, 'createPathDirectory');
     $method->setAccessible(true);
@@ -217,7 +221,7 @@ test('createPathDirectory handles kebab-case path segments', function () {
 });
 
 test('createPathDirectory handles missing path key', function () {
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
+    $command = new MakeSwaggerMcpToolCommand;
 
     $method = new ReflectionMethod($command, 'createPathDirectory');
     $method->setAccessible(true);
@@ -406,10 +410,10 @@ test('swagger tool generation creates path-based directories', function () {
 
 // Test interactive grouping option selection
 test('getGroupingOption returns provided option when set', function () {
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
+    $command = new MakeSwaggerMcpToolCommand;
 
     // Mock the option method to return a value
-    $command = \Mockery::mock($command)->makePartial();
+    $command = Mockery::mock($command)->makePartial();
     $command->shouldReceive('option')->with('group-by')->andReturn('path');
     $command->shouldReceive('option')->with('no-interaction')->andReturn(false);
 
@@ -422,10 +426,10 @@ test('getGroupingOption returns provided option when set', function () {
 });
 
 test('getGroupingOption returns tag for non-interactive mode when no option provided', function () {
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
+    $command = new MakeSwaggerMcpToolCommand;
 
     // Mock the option method to return null (no option provided)
-    $command = \Mockery::mock($command)->makePartial();
+    $command = Mockery::mock($command)->makePartial();
     $command->shouldReceive('option')->with('group-by')->andReturn(null);
     $command->shouldReceive('option')->with('no-interaction')->andReturn(true);
 
@@ -454,11 +458,11 @@ test('getGroupingOption handles none selection in interactive mode', function ()
 
 // Test generateGroupingPreviews method
 test('generateGroupingPreviews returns preview examples for all grouping options', function () {
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
+    $command = new MakeSwaggerMcpToolCommand;
 
     // Mock the parser and converter
-    $mockParser = \Mockery::mock(\OPGG\LaravelMcpServer\Services\SwaggerParser\SwaggerParser::class);
-    $mockConverter = \Mockery::mock(\OPGG\LaravelMcpServer\Services\SwaggerParser\SwaggerToMcpConverter::class);
+    $mockParser = Mockery::mock(SwaggerParser::class);
+    $mockConverter = Mockery::mock(SwaggerToMcpConverter::class);
 
     // Sample endpoints for testing
     $sampleEndpoints = [
@@ -496,11 +500,11 @@ test('generateGroupingPreviews returns preview examples for all grouping options
 });
 
 test('generateGroupingPreviews handles endpoints with no tags', function () {
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
+    $command = new MakeSwaggerMcpToolCommand;
 
     // Mock the parser and converter
-    $mockParser = \Mockery::mock(\OPGG\LaravelMcpServer\Services\SwaggerParser\SwaggerParser::class);
-    $mockConverter = \Mockery::mock(\OPGG\LaravelMcpServer\Services\SwaggerParser\SwaggerToMcpConverter::class);
+    $mockParser = Mockery::mock(SwaggerParser::class);
+    $mockConverter = Mockery::mock(SwaggerToMcpConverter::class);
 
     // Endpoints without tags
     $sampleEndpoints = [
@@ -531,7 +535,7 @@ test('generateGroupingPreviews handles endpoints with no tags', function () {
 });
 
 test('getGroupingOption displays previews in interactive mode', function () {
-    $command = \Mockery::mock(\OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $command = Mockery::mock(MakeSwaggerMcpToolCommand::class)->makePartial()->shouldAllowMockingProtectedMethods();
 
     // Mock the option method to return null (no group-by option provided)
     $command->shouldReceive('option')->with('group-by')->andReturn(null);
@@ -553,7 +557,7 @@ test('getGroupingOption displays previews in interactive mode', function () {
 
     // Mock choice method
     $command->shouldReceive('choice')
-        ->with('Select grouping method', \Mockery::any(), 0)
+        ->with('Select grouping method', Mockery::any(), 0)
         ->andReturn('Tag-based grouping (organize by OpenAPI tags)');
 
     $method = new ReflectionMethod($command, 'getGroupingOption');

--- a/tests/Console/Commands/TagDirectoryEdgeCasesTest.php
+++ b/tests/Console/Commands/TagDirectoryEdgeCasesTest.php
@@ -1,6 +1,10 @@
 <?php
 
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
+use OPGG\LaravelMcpServer\Console\Commands\MakeMcpResourceCommand;
+use OPGG\LaravelMcpServer\Console\Commands\MakeMcpToolCommand;
+use OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand;
 
 beforeEach(function () {
     // Clean up directories before each test
@@ -15,8 +19,8 @@ afterEach(function () {
 });
 
 test('tag directory handles complex special characters', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeSwaggerMcpToolCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'createTagDirectory');
     $method->setAccessible(true);
@@ -40,8 +44,8 @@ test('tag directory handles complex special characters', function () {
 });
 
 test('tag directory handles empty strings and whitespace', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeSwaggerMcpToolCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'createTagDirectory');
     $method->setAccessible(true);
@@ -59,8 +63,8 @@ test('tag directory handles empty strings and whitespace', function () {
 });
 
 test('tag directory handles unicode characters', function () {
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $command = new \OPGG\LaravelMcpServer\Console\Commands\MakeSwaggerMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $command = new MakeSwaggerMcpToolCommand($filesystem);
 
     $method = new ReflectionMethod($command, 'createTagDirectory');
     $method->setAccessible(true);
@@ -79,9 +83,9 @@ test('tag directory handles unicode characters', function () {
 
 test('tool and resource creation in same tag directory works correctly', function () {
     // Simulate swagger generating both tool and resource with same tag
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $toolCommand = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpToolCommand($filesystem);
-    $resourceCommand = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpResourceCommand($filesystem);
+    $filesystem = new Filesystem;
+    $toolCommand = new MakeMcpToolCommand($filesystem);
+    $resourceCommand = new MakeMcpResourceCommand($filesystem);
 
     // Set up both commands with same tag directory
     $toolProperty = new ReflectionProperty($toolCommand, 'dynamicParams');
@@ -111,8 +115,8 @@ test('tool and resource creation in same tag directory works correctly', functio
 
 test('deeply nested tag directories work correctly', function () {
     // Test creating very deep directory structures
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $toolCommand = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $toolCommand = new MakeMcpToolCommand($filesystem);
 
     $property = new ReflectionProperty($toolCommand, 'dynamicParams');
     $property->setAccessible(true);
@@ -136,9 +140,9 @@ test('deeply nested tag directories work correctly', function () {
 
 test('namespace collision prevention with different tags', function () {
     // Test that tools with same name but different tags get different namespaces
-    $filesystem = new \Illuminate\Filesystem\Filesystem;
-    $toolCommand1 = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpToolCommand($filesystem);
-    $toolCommand2 = new \OPGG\LaravelMcpServer\Console\Commands\MakeMcpToolCommand($filesystem);
+    $filesystem = new Filesystem;
+    $toolCommand1 = new MakeMcpToolCommand($filesystem);
+    $toolCommand2 = new MakeMcpToolCommand($filesystem);
 
     // Set up different tag directories
     $property1 = new ReflectionProperty($toolCommand1, 'dynamicParams');

--- a/tests/Console/Commands/TestMcpToolCommandTest.php
+++ b/tests/Console/Commands/TestMcpToolCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use OPGG\LaravelMcpServer\Tests\Fixtures\Resolvers\PhaseToolResolver;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\AutoStructuredArrayTool;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\LegacyArrayTool;
 
@@ -42,6 +43,19 @@ test('mcp:test-tool warns when endpoint filter is not registered', function () {
         '--endpoint' => '/unknown',
     ])
         ->expectsOutputToContain("Endpoint '/unknown' is not registered via Route::mcp().")
-        ->expectsOutputToContain('No MCP tools are registered. Use Route::mcp(...)->tools([...]) to register endpoint tools.')
+        ->expectsOutputToContain('No MCP tools are registered. Use Route::mcp(...)->tools([...]) or ->dynamicTools(...) to register endpoint tools.')
+        ->assertExitCode(0);
+});
+
+test('mcp:test-tool lists declared tools from dynamic tool resolvers', function () {
+    Route::mcp('/dynamic-mcp')
+        ->dynamicTools(PhaseToolResolver::class);
+
+    $this->artisan('mcp:test-tool', [
+        '--list' => true,
+        '--endpoint' => '/dynamic-mcp',
+    ])
+        ->expectsOutputToContain('legacy-array-tool')
+        ->expectsOutputToContain('structured-only-tool')
         ->assertExitCode(0);
 });

--- a/tests/Fixtures/Resolvers/ExplodingToolResolver.php
+++ b/tests/Fixtures/Resolvers/ExplodingToolResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace OPGG\LaravelMcpServer\Tests\Fixtures\Resolvers;
+
+use LogicException;
+use OPGG\LaravelMcpServer\Data\ToolResolutionContext;
+use OPGG\LaravelMcpServer\Routing\McpEndpointDefinition;
+use OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface;
+use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\LegacyArrayTool;
+
+class ExplodingToolResolver implements DynamicToolResolverInterface
+{
+    public function declaredTools(McpEndpointDefinition $endpoint): array
+    {
+        return [
+            LegacyArrayTool::class,
+        ];
+    }
+
+    public function resolve(McpEndpointDefinition $endpoint, ToolResolutionContext $context): array
+    {
+        throw new LogicException('Dynamic tool resolver should not run for non-tools requests.');
+    }
+}

--- a/tests/Fixtures/Resolvers/PhaseToolResolver.php
+++ b/tests/Fixtures/Resolvers/PhaseToolResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace OPGG\LaravelMcpServer\Tests\Fixtures\Resolvers;
+
+use OPGG\LaravelMcpServer\Data\ToolResolutionContext;
+use OPGG\LaravelMcpServer\Routing\McpEndpointDefinition;
+use OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface;
+use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\LegacyArrayTool;
+use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\StructuredOnlyTool;
+
+class PhaseToolResolver implements DynamicToolResolverInterface
+{
+    public function declaredTools(McpEndpointDefinition $endpoint): array
+    {
+        return [
+            LegacyArrayTool::class,
+            StructuredOnlyTool::class,
+        ];
+    }
+
+    public function resolve(McpEndpointDefinition $endpoint, ToolResolutionContext $context): array
+    {
+        return match ($context->queryParameters['phase'] ?? null) {
+            'lobby' => [LegacyArrayTool::class],
+            'inprogress' => [StructuredOnlyTool::class],
+            default => $this->declaredTools($endpoint),
+        };
+    }
+}

--- a/tests/Fixtures/Resolvers/ToolApiPhaseToolResolver.php
+++ b/tests/Fixtures/Resolvers/ToolApiPhaseToolResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace OPGG\LaravelMcpServer\Tests\Fixtures\Resolvers;
+
+use OPGG\LaravelMcpServer\Data\ToolResolutionContext;
+use OPGG\LaravelMcpServer\Routing\McpEndpointDefinition;
+use OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface;
+use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\LegacyArrayTool;
+use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\StructuredOnlyTool;
+
+class ToolApiPhaseToolResolver implements DynamicToolResolverInterface
+{
+    public function declaredTools(McpEndpointDefinition $endpoint): array
+    {
+        return [
+            LegacyArrayTool::class,
+            StructuredOnlyTool::class,
+        ];
+    }
+
+    public function resolve(McpEndpointDefinition $endpoint, ToolResolutionContext $context): array
+    {
+        return match ($context->queryParameters['phase'] ?? null) {
+            'lobby' => [LegacyArrayTool::class],
+            'inprogress' => [StructuredOnlyTool::class],
+            default => $this->declaredTools($endpoint),
+        };
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function consumedQueryParameters(): array
+    {
+        return ['phase'];
+    }
+}

--- a/tests/Http/StreamableHttpTest.php
+++ b/tests/Http/StreamableHttpTest.php
@@ -8,6 +8,8 @@ use OPGG\LaravelMcpServer\Routing\McpRouteRegistrar;
 use OPGG\LaravelMcpServer\Services\ToolService\Examples\HelloWorldTool;
 use OPGG\LaravelMcpServer\Services\ToolService\Examples\VersionCheckTool;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Handlers\CustomToolsCallHandler;
+use OPGG\LaravelMcpServer\Tests\Fixtures\Resolvers\ExplodingToolResolver;
+use OPGG\LaravelMcpServer\Tests\Fixtures\Resolvers\PhaseToolResolver;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\AutoStructuredArrayTool;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\CompactEnumTool;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\ConstructionCounterTool;
@@ -137,6 +139,119 @@ test('tools/list still works when custom tools/call handler is configured', func
     expect(collect($tools)->pluck('name')->all())->toContain('hello-world', 'check-version');
 });
 
+test('tools/list filters tools using query string resolver', function () {
+    Route::mcp('/filtered-mcp')
+        ->setServerInfo(
+            name: 'Filtered HTTP Test MCP',
+            version: '1.0.0',
+        )
+        ->dynamicTools(PhaseToolResolver::class);
+
+    $payload = [
+        'jsonrpc' => '2.0',
+        'id' => 1201,
+        'method' => 'tools/list',
+        'params' => [],
+    ];
+
+    $lobbyResponse = $this->postJson('/filtered-mcp?phase=lobby', $payload);
+    $lobbyResponse->assertStatus(200);
+    expect(collect($lobbyResponse->json('result.tools'))->pluck('name')->all())
+        ->toBe(['legacy-array-tool']);
+
+    $inProgressResponse = $this->postJson('/filtered-mcp?phase=inprogress', $payload);
+    $inProgressResponse->assertStatus(200);
+    expect(collect($inProgressResponse->json('result.tools'))->pluck('name')->all())
+        ->toBe(['structured-only-tool']);
+
+    $defaultResponse = $this->postJson('/filtered-mcp', $payload);
+    $defaultResponse->assertStatus(200);
+    expect(collect($defaultResponse->json('result.tools'))->pluck('name')->all())
+        ->toBe(['legacy-array-tool', 'structured-only-tool']);
+});
+
+test('tools/call uses the same query string filter as tools/list', function () {
+    Route::mcp('/filtered-call-mcp')
+        ->setServerInfo(
+            name: 'Filtered Call HTTP Test MCP',
+            version: '1.0.0',
+        )
+        ->dynamicTools(PhaseToolResolver::class);
+
+    $visiblePayload = [
+        'jsonrpc' => '2.0',
+        'id' => 1202,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'structured-only-tool',
+            'arguments' => [
+                'region' => 'KR',
+            ],
+        ],
+    ];
+
+    $visibleResponse = $this->postJson('/filtered-call-mcp?phase=inprogress', $visiblePayload);
+    $visibleResponse->assertStatus(200);
+    $visibleResponse->assertJsonPath('result.structuredContent.region', 'KR');
+
+    $hiddenPayload = [
+        'jsonrpc' => '2.0',
+        'id' => 1203,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'legacy-array-tool',
+            'arguments' => [],
+        ],
+    ];
+
+    $hiddenResponse = $this->postJson('/filtered-call-mcp?phase=inprogress', $hiddenPayload);
+    $hiddenResponse->assertStatus(200);
+    $hiddenResponse->assertJsonPath('error.code', -32601);
+    $hiddenResponse->assertJsonPath('error.message', "Tool 'legacy-array-tool' not found");
+});
+
+test('custom tools/call handler receives query string filtered tool repository', function () {
+    Route::mcp('/filtered-tracked-call-mcp')
+        ->setServerInfo(
+            name: 'Filtered Tracked Call HTTP Test MCP',
+            version: '1.0.0',
+        )
+        ->dynamicTools(PhaseToolResolver::class)
+        ->toolsCallHandler(CustomToolsCallHandler::class);
+
+    $visiblePayload = [
+        'jsonrpc' => '2.0',
+        'id' => 1204,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'structured-only-tool',
+            'arguments' => [
+                'region' => 'EUW',
+            ],
+        ],
+    ];
+
+    $visibleResponse = $this->postJson('/filtered-tracked-call-mcp?phase=inprogress', $visiblePayload);
+    $visibleResponse->assertStatus(200);
+    $visibleResponse->assertJsonPath('result.structuredContent.region', 'EUW');
+    $visibleResponse->assertJsonPath('result._meta.handler', 'custom-tools-call-handler');
+
+    $hiddenPayload = [
+        'jsonrpc' => '2.0',
+        'id' => 1205,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'legacy-array-tool',
+            'arguments' => [],
+        ],
+    ];
+
+    $hiddenResponse = $this->postJson('/filtered-tracked-call-mcp?phase=inprogress', $hiddenPayload);
+    $hiddenResponse->assertStatus(200);
+    $hiddenResponse->assertJsonPath('error.code', -32601);
+    $hiddenResponse->assertJsonPath('error.message', "Tool 'legacy-array-tool' not found");
+});
+
 test('initialize does not instantiate tool classes for non-tool requests', function () {
     ConstructionCounterTool::resetCounter();
     registerMcpEndpoint([ConstructionCounterTool::class]);
@@ -159,6 +274,33 @@ test('initialize does not instantiate tool classes for non-tool requests', funct
     $response->assertStatus(200);
     expect($response->json('result.protocolVersion'))->toBe('2025-11-25');
     expect(ConstructionCounterTool::$constructionCount)->toBe(0);
+});
+
+test('initialize does not evaluate dynamic tool resolvers for non-tool requests', function () {
+    Route::mcp('/dynamic-mcp')
+        ->setServerInfo(
+            name: 'Dynamic HTTP Test MCP',
+            version: '1.0.0',
+        )
+        ->dynamicTools(ExplodingToolResolver::class);
+
+    $payload = [
+        'jsonrpc' => '2.0',
+        'id' => 9011,
+        'method' => 'initialize',
+        'params' => [
+            'protocolVersion' => '2025-11-25',
+            'capabilities' => [],
+            'clientInfo' => [
+                'name' => 'perf-test-client',
+                'version' => '1.0.0',
+            ],
+        ],
+    ];
+
+    $response = $this->postJson('/dynamic-mcp', $payload);
+    $response->assertStatus(200);
+    expect($response->json('result.protocolVersion'))->toBe('2025-11-25');
 });
 
 test('tool classes are instantiated when tools endpoints are requested', function () {

--- a/tests/Http/ToolApiHttpTest.php
+++ b/tests/Http/ToolApiHttpTest.php
@@ -1,6 +1,11 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use OPGG\LaravelMcpServer\Data\ToolResolutionContext;
+use OPGG\LaravelMcpServer\Routing\McpEndpointDefinition;
+use OPGG\LaravelMcpServer\Services\ToolService\DynamicToolResolverInterface;
+use OPGG\LaravelMcpServer\Tests\Fixtures\Resolvers\PhaseToolResolver;
+use OPGG\LaravelMcpServer\Tests\Fixtures\Resolvers\ToolApiPhaseToolResolver;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\LegacyArrayTool;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\SharedNamePrimaryTool;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\SharedNameSecondaryTool;
@@ -71,6 +76,27 @@ test('query parameters take precedence over json body on /tools/{tool_name}', fu
     $response->assertJsonPath('echo.name', 'query-tester');
 });
 
+test('query parameters take precedence over malformed json body on /tools/{tool_name}', function () {
+    registerToolApiEndpoint([LegacyArrayTool::class]);
+
+    $response = $this->call(
+        method: 'POST',
+        uri: '/tools/legacy-array-tool?name=query-tester',
+        parameters: [],
+        cookies: [],
+        files: [],
+        server: [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'application/json',
+        ],
+        content: '{"invalid":',
+    );
+
+    $response->assertStatus(200);
+    $response->assertJsonPath('status', 'ok');
+    $response->assertJsonPath('echo.name', 'query-tester');
+});
+
 test('repeated query parameters are normalized to arrays on /tools/{tool_name}', function () {
     registerToolApiEndpoint([LegacyArrayTool::class]);
 
@@ -86,6 +112,106 @@ test('tool api route returns 404 when tool name is unknown', function () {
     registerToolApiEndpoint([LegacyArrayTool::class]);
 
     $response = $this->postJson('/tools/unknown-tool', []);
+
+    $response->assertStatus(404);
+    $response->assertJsonPath('code', -32601);
+});
+
+test('tool api route keeps filter query separate from tool arguments', function () {
+    Route::mcp('/filtered-body-mcp')
+        ->setServerInfo(
+            name: 'Filtered Tool API Body Test MCP',
+            version: '1.0.0',
+        )
+        ->enabledApi()
+        ->dynamicTools(ToolApiPhaseToolResolver::class);
+
+    $response = $this->postJson('/tools/legacy-array-tool?phase=lobby&name=query-tester', [
+        'region' => 'NA',
+    ]);
+
+    $response->assertStatus(200);
+    $response->assertJsonPath('status', 'ok');
+    $response->assertJsonPath('echo.name', 'query-tester');
+    $response->assertJsonPath('echo.region', 'NA');
+    expect($response->json('echo'))->not->toHaveKey('phase');
+});
+
+test('tool api route returns parse error when only filter query parameters are present', function () {
+    Route::mcp('/filtered-body-mcp')
+        ->setServerInfo(
+            name: 'Filtered Tool API Body Test MCP',
+            version: '1.0.0',
+        )
+        ->enabledApi()
+        ->dynamicTools(ToolApiPhaseToolResolver::class);
+
+    $response = $this->call(
+        method: 'POST',
+        uri: '/tools/legacy-array-tool?phase=lobby',
+        parameters: [],
+        cookies: [],
+        files: [],
+        server: [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'application/json',
+        ],
+        content: '{"invalid":',
+    );
+
+    $response->assertStatus(400);
+    $response->assertJsonPath('code', -32700);
+});
+
+test('tool api route respects query string tool filtering', function () {
+    Route::mcp('/filtered-mcp')
+        ->setServerInfo(
+            name: 'Filtered Tool API Test MCP',
+            version: '1.0.0',
+        )
+        ->enabledApi()
+        ->dynamicTools(PhaseToolResolver::class);
+
+    $visibleResponse = $this->post('/tools/structured-only-tool?phase=inprogress&region=NA');
+
+    $visibleResponse->assertStatus(200);
+    $visibleResponse->assertJsonPath('structuredContent.status', 'ok');
+    $visibleResponse->assertJsonPath('structuredContent.region', 'NA');
+
+    $hiddenResponse = $this->postJson('/tools/legacy-array-tool?phase=inprogress', []);
+
+    $hiddenResponse->assertStatus(404);
+    $hiddenResponse->assertJsonPath('code', -32601);
+});
+
+test('filtered tool does not fall through to a later endpoint with the same tool name', function () {
+    $resolver = new class implements DynamicToolResolverInterface
+    {
+        public function declaredTools(McpEndpointDefinition $endpoint): array
+        {
+            return [SharedNamePrimaryTool::class];
+        }
+
+        public function resolve(McpEndpointDefinition $endpoint, ToolResolutionContext $context): array
+        {
+            return match ($context->queryParameters['phase'] ?? null) {
+                'before' => [SharedNamePrimaryTool::class],
+                default => [],
+            };
+        }
+    };
+
+    Route::mcp('/filtered-primary')
+        ->setServerInfo(
+            name: 'Filtered Primary Tool API Test MCP',
+            version: '1.0.0',
+        )
+        ->enabledApi()
+        ->dynamicTools($resolver::class);
+
+    registerToolApiEndpoint([SharedNameSecondaryTool::class], '/secondary-mcp');
+
+    $response = $this->postJson('/tools/shared-name-tool?phase=after', []);
 
     $response->assertStatus(404);
     $response->assertJsonPath('code', -32601);

--- a/tests/LaravelMcpServerServiceProviderTest.php
+++ b/tests/LaravelMcpServerServiceProviderTest.php
@@ -212,15 +212,15 @@ it('stores dynamic tool resolver class from fluent route builder', function () {
 it('rejects non tools/call handler classes', function () {
     bootProvider();
 
-    expect(fn () => Route::mcp('/invalid-tools-handler')->toolsCallHandler(\stdClass::class))
-        ->toThrow(\InvalidArgumentException::class);
+    expect(fn () => Route::mcp('/invalid-tools-handler')->toolsCallHandler(stdClass::class))
+        ->toThrow(InvalidArgumentException::class);
 });
 
 it('rejects non dynamic tools resolver classes', function () {
     bootProvider();
 
-    expect(fn () => Route::mcp('/invalid-dynamic-tools-resolver')->dynamicTools(\stdClass::class))
-        ->toThrow(\InvalidArgumentException::class);
+    expect(fn () => Route::mcp('/invalid-dynamic-tools-resolver')->dynamicTools(stdClass::class))
+        ->toThrow(InvalidArgumentException::class);
 });
 
 it('rejects mixing static tools with dynamic tools resolvers', function () {
@@ -229,12 +229,12 @@ it('rejects mixing static tools with dynamic tools resolvers', function () {
     expect(fn () => Route::mcp('/mixed-static-first')
         ->tools([LegacyArrayTool::class])
         ->dynamicTools(PhaseToolResolver::class))
-        ->toThrow(\InvalidArgumentException::class);
+        ->toThrow(InvalidArgumentException::class);
 
     expect(fn () => Route::mcp('/mixed-dynamic-first')
         ->dynamicTools(PhaseToolResolver::class)
         ->tools([LegacyArrayTool::class]))
-        ->toThrow(\InvalidArgumentException::class);
+        ->toThrow(InvalidArgumentException::class);
 });
 
 it('keeps existing name and version when setServerInfo is partially applied', function () {

--- a/tests/LaravelMcpServerServiceProviderTest.php
+++ b/tests/LaravelMcpServerServiceProviderTest.php
@@ -8,6 +8,7 @@ use OPGG\LaravelMcpServer\Routing\McpEndpointRegistry;
 use OPGG\LaravelMcpServer\Routing\McpRouteBuilder;
 use OPGG\LaravelMcpServer\Routing\McpRouteRegistrar;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Handlers\CustomToolsCallHandler;
+use OPGG\LaravelMcpServer\Tests\Fixtures\Resolvers\PhaseToolResolver;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\AutoStructuredArrayTool;
 use OPGG\LaravelMcpServer\Tests\Fixtures\Tools\LegacyArrayTool;
 
@@ -58,6 +59,8 @@ it('exposes setServerInfo as the only public server metadata mutator', function 
     expect(method_exists(McpRouteBuilder::class, 'setServerInfo'))->toBeTrue();
     expect(method_exists(McpRouteBuilder::class, 'setConfig'))->toBeTrue();
     expect(method_exists(McpRouteBuilder::class, 'enabledApi'))->toBeTrue();
+    expect(method_exists(McpRouteBuilder::class, 'dynamicTools'))->toBeTrue();
+    expect(method_exists(McpRouteBuilder::class, 'toolFilterResolver'))->toBeFalse();
     expect(method_exists(McpRouteBuilder::class, 'setName'))->toBeFalse();
     expect(method_exists(McpRouteBuilder::class, 'setVersion'))->toBeFalse();
     expect(method_exists(McpRouteBuilder::class, 'setTitle'))->toBeFalse();
@@ -187,10 +190,50 @@ it('stores custom tools/call handler class from fluent route builder', function 
     expect($definitions[0]->toolsCallHandler)->toBe(CustomToolsCallHandler::class);
 });
 
+it('stores dynamic tool resolver class from fluent route builder', function () {
+    bootProvider();
+
+    Route::mcp('/filtered-tools')
+        ->setServerInfo(
+            name: 'Filtered Tools',
+            version: '2.0.0',
+        )
+        ->dynamicTools(PhaseToolResolver::class);
+
+    /** @var McpEndpointRegistry $registry */
+    $registry = app(McpEndpointRegistry::class);
+    $definitions = array_values($registry->all());
+
+    expect($definitions)->toHaveCount(1);
+    expect($definitions[0]->dynamicToolsResolver)->toBe(PhaseToolResolver::class);
+    expect($definitions[0]->tools)->toBe([]);
+});
+
 it('rejects non tools/call handler classes', function () {
     bootProvider();
 
     expect(fn () => Route::mcp('/invalid-tools-handler')->toolsCallHandler(\stdClass::class))
+        ->toThrow(\InvalidArgumentException::class);
+});
+
+it('rejects non dynamic tools resolver classes', function () {
+    bootProvider();
+
+    expect(fn () => Route::mcp('/invalid-dynamic-tools-resolver')->dynamicTools(\stdClass::class))
+        ->toThrow(\InvalidArgumentException::class);
+});
+
+it('rejects mixing static tools with dynamic tools resolvers', function () {
+    bootProvider();
+
+    expect(fn () => Route::mcp('/mixed-static-first')
+        ->tools([LegacyArrayTool::class])
+        ->dynamicTools(PhaseToolResolver::class))
+        ->toThrow(\InvalidArgumentException::class);
+
+    expect(fn () => Route::mcp('/mixed-dynamic-first')
+        ->dynamicTools(PhaseToolResolver::class)
+        ->tools([LegacyArrayTool::class]))
         ->toThrow(\InvalidArgumentException::class);
 });
 
@@ -318,7 +361,7 @@ it('replaces existing endpoint definition when same path and domain are register
     expect($definitions[0]->tools)->toBe([AutoStructuredArrayTool::class]);
 });
 
-it('stores endpoint definition payload on registered routes and keeps it synchronized', function () {
+it('stores dynamic endpoint definition payload on registered routes and keeps it synchronized', function () {
     bootProvider();
 
     Route::mcp('/cached-mcp')
@@ -328,7 +371,7 @@ it('stores endpoint definition payload on registered routes and keeps it synchro
             description: 'Route cache payload',
         )
         ->setConfig(compactEnumExampleCount: 4)
-        ->tools([LegacyArrayTool::class])
+        ->dynamicTools(PhaseToolResolver::class)
         ->toolListChanged()
         ->resourcesSubscribe()
         ->resourcesListChanged()
@@ -349,7 +392,8 @@ it('stores endpoint definition payload on registered routes and keeps it synchro
         expect($definition['name'])->toBe('Cached MCP');
         expect($definition['version'])->toBe('3.1.4');
         expect($definition['description'])->toBe('Route cache payload');
-        expect($definition['tools'])->toBe([LegacyArrayTool::class]);
+        expect($definition['tools'])->toBe([]);
+        expect($definition['dynamicToolsResolver'])->toBe(PhaseToolResolver::class);
         expect($definition['toolListChanged'])->toBeTrue();
         expect($definition['resourcesSubscribe'])->toBeTrue();
         expect($definition['resourcesListChanged'])->toBeTrue();

--- a/tests/Lumen/TestCase.php
+++ b/tests/Lumen/TestCase.php
@@ -3,6 +3,8 @@
 namespace OPGG\LaravelMcpServer\Tests\Lumen;
 
 use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Config\Repository;
+use Laravel\Lumen\Application;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
@@ -16,14 +18,14 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        if (! class_exists(\Laravel\Lumen\Application::class)) {
+        if (! class_exists(Application::class)) {
             $this->markTestSkipped('Laravel Lumen is not installed.');
         }
 
         $this->app = new TestingApplication($this->basePath());
         $this->app->instance('path.config', $this->basePath('config'));
         $this->app->instance('config', new ConfigRepository);
-        $this->app->alias('config', \Illuminate\Contracts\Config\Repository::class);
+        $this->app->alias('config', Repository::class);
 
         $this->app->withFacades();
         $this->app->withEloquent();


### PR DESCRIPTION
### New Features

* MCP endpoints can declare dynamic tool resolvers that switch the exposed tool set per request query string while keeping `tools/list`, `tools/call`, and `POST /tools/{tool_name}` execution in sync.
* OpenAPI export now includes tools declared by dynamic resolvers, so generated endpoint docs reflect the full dynamic route catalog.
* `mcp:test-tool` now lists tools declared by dynamic resolvers, so local inspection matches each route's declared tool catalog.

### Bug Fixes

* Tool API requests with filter-only query parameters returned parse errors for malformed JSON bodies instead of silently executing with empty arguments.

